### PR TITLE
Fix E0382 borrow-after-move errors in wbxml.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1597,7 +1597,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2122,7 +2122,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2179,7 +2179,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2446,7 +2446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2529,7 +2529,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2618,9 +2618,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3164,7 +3164,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 rust-version = "1.94.1"
 
 [dependencies]
-tokio = { version = "^1.51.0", features = ["full", "tracing", "signal"] }
+tokio = { version = "^1.51.1", features = ["full", "tracing", "signal"] }
 axum = { version = "^0.8.8", features = ["macros", "tracing"] }
 hyper = "^1.9.0"
 hyper-util = "^0.1.20"

--- a/src/autodiscover.rs
+++ b/src/autodiscover.rs
@@ -27,7 +27,10 @@ fn no_cache_headers_xml() -> Vec<(&'static str, &'static str)> {
         ("X-Content-Type-Options", "nosniff"),
         ("Referrer-Policy", "no-referrer"),
         ("X-Frame-Options", "DENY"),
-        ("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; sandbox"),
+        (
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'; sandbox",
+        ),
         ("X-XSS-Protection", "1; mode=block"),
     ]
 }
@@ -39,7 +42,10 @@ fn no_cache_headers_json() -> Vec<(&'static str, &'static str)> {
         ("X-Content-Type-Options", "nosniff"),
         ("Referrer-Policy", "no-referrer"),
         ("X-Frame-Options", "DENY"),
-        ("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; sandbox"),
+        (
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'; sandbox",
+        ),
         ("X-XSS-Protection", "1; mode=block"),
     ]
 }
@@ -51,7 +57,10 @@ fn no_cache_headers_soap() -> Vec<(&'static str, &'static str)> {
         ("X-Content-Type-Options", "nosniff"),
         ("Referrer-Policy", "no-referrer"),
         ("X-Frame-Options", "DENY"),
-        ("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; sandbox"),
+        (
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'; sandbox",
+        ),
         ("X-XSS-Protection", "1; mode=block"),
     ]
 }
@@ -66,7 +75,11 @@ fn extract_email_from_v1_xml(body: &str) -> Option<String> {
         .map(|i| i + "<EMailAddress>".len())?;
     let end = body[start..].find("</EMailAddress>").map(|i| start + i)?;
     let email = body[start..end].trim().to_string();
-    if email.contains('@') { Some(email) } else { None }
+    if email.contains('@') {
+        Some(email)
+    } else {
+        None
+    }
 }
 
 fn extract_email_from_soap(body: &str) -> Option<String> {
@@ -75,12 +88,12 @@ fn extract_email_from_soap(body: &str) -> Option<String> {
         ("<a:EMailAddress>", "</a:EMailAddress>"),
         ("<Mailbox>", "</Mailbox>"),
     ] {
-        if let Some(start) = body.find(open).map(|i| i + open.len()) {
-            if let Some(end) = body[start..].find(close).map(|i| start + i) {
-                let email = body[start..end].trim().to_string();
-                if email.contains('@') {
-                    return Some(email);
-                }
+        if let Some(start) = body.find(open).map(|i| i + open.len())
+            && let Some(end) = body[start..].find(close).map(|i| start + i)
+        {
+            let email = body[start..end].trim().to_string();
+            if email.contains('@') {
+                return Some(email);
             }
         }
     }
@@ -264,7 +277,10 @@ mod tests {
     #[test]
     fn extract_email_from_v1_body() {
         let body = r#"<Autodiscover xmlns="..."><Request><EMailAddress>alice@example.com</EMailAddress></Request></Autodiscover>"#;
-        assert_eq!(extract_email_from_body_xml(body), Some("alice@example.com".to_string()));
+        assert_eq!(
+            extract_email_from_body_xml(body),
+            Some("alice@example.com".to_string())
+        );
     }
 
     #[test]
@@ -278,7 +294,8 @@ mod tests {
 
     #[test]
     fn autodiscover_json_activesync_only() {
-        let (_, _, body) = handle_autodiscover_json("exchange.example.com", Some("ActiveSync"), None);
+        let (_, _, body) =
+            handle_autodiscover_json("exchange.example.com", Some("ActiveSync"), None);
         assert!(body.contains("ActiveSync"));
         assert!(!body.contains("EwsUrl"));
     }
@@ -292,14 +309,16 @@ mod tests {
 
     #[test]
     fn autodiscover_json_autodiscoverv1() {
-        let (_, _, body) = handle_autodiscover_json("exchange.example.com", Some("AutodiscoverV1"), None);
+        let (_, _, body) =
+            handle_autodiscover_json("exchange.example.com", Some("AutodiscoverV1"), None);
         assert!(body.contains("AutodiscoverV1"));
         assert!(body.contains("autodiscover.xml"));
     }
 
     #[test]
     fn autodiscover_xml_contains_required_fields() {
-        let (status, _, body) = handle_autodiscover_xml("exchange.example.com", "", "alice@example.com");
+        let (status, _, body) =
+            handle_autodiscover_xml("exchange.example.com", "", "alice@example.com");
         assert_eq!(status, StatusCode::OK);
         assert!(body.contains("<Type>EXCH</Type>"));
         assert!(body.contains("<Type>EXPR</Type>"));

--- a/src/caldav.rs
+++ b/src/caldav.rs
@@ -3,7 +3,7 @@ use crate::config::Config;
 use anyhow::Result;
 use reqwest::header::{CONTENT_TYPE, ETAG, IF_MATCH, IF_NONE_MATCH};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
-use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use sha2::{Digest, Sha256};
 use std::time::Duration;
 use uuid::Uuid;
@@ -15,23 +15,21 @@ pub struct CaldavClient {
 
 impl CaldavClient {
     pub fn new(cfg: &Config) -> Result<Self> {
-    let retry_policy = ExponentialBackoff::builder()
-        .build_with_max_retries(3);
-    let client = ClientBuilder::new(
-        reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()?,
-    )
-    .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-    .build();
-    Ok(Self { base: cfg.caldav_base.clone(), client })
-    }        
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+        let client = ClientBuilder::new(
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()?,
+        )
+        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+        .build();
+        Ok(Self {
+            base: cfg.caldav_base.clone(),
+            client,
+        })
+    }
 
-    pub async fn find_user_calendars(
-        &self,
-        username: &str,
-        password: &str,
-    ) -> Result<Vec<String>> {
+    pub async fn find_user_calendars(&self, username: &str, password: &str) -> Result<Vec<String>> {
         let home_url = format!("{}/cal/{}/", self.base.trim_end_matches('/'), username);
 
         let propfind_body = r#"<?xml version="1.0" encoding="utf-8"?>
@@ -97,8 +95,11 @@ impl CaldavClient {
             }
         }
 
-        let default_url =
-            format!("{}/cal/{}/default/", self.base.trim_end_matches('/'), username);
+        let default_url = format!(
+            "{}/cal/{}/default/",
+            self.base.trim_end_matches('/'),
+            username
+        );
         tracing::debug!(
             "caldav: using fallback default calendar URL: {}",
             default_url
@@ -139,10 +140,7 @@ impl CaldavClient {
             .send()
             .await?;
         if !resp.status().is_success() && resp.status().as_u16() != 207 {
-            return Err(anyhow::anyhow!(
-                "failed to query events: {}",
-                resp.status()
-            ));
+            return Err(anyhow::anyhow!("failed to query events: {}", resp.status()));
         }
         Ok(resp.text().await?)
     }
@@ -161,10 +159,7 @@ impl CaldavClient {
             .send()
             .await?;
         if !resp.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "failed to fetch event: {}",
-                resp.status()
-            ));
+            return Err(anyhow::anyhow!("failed to fetch event: {}", resp.status()));
         }
         let etag = resp
             .headers()
@@ -199,10 +194,7 @@ impl CaldavClient {
 
         let resp = req.send().await?;
         if !resp.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "failed to write event: {}",
-                resp.status()
-            ));
+            return Err(anyhow::anyhow!("failed to write event: {}", resp.status()));
         }
         let etag = resp
             .headers()
@@ -227,10 +219,7 @@ impl CaldavClient {
         }
         let resp = req.send().await?;
         if !resp.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "failed to delete event: {}",
-                resp.status()
-            ));
+            return Err(anyhow::anyhow!("failed to delete event: {}", resp.status()));
         }
         Ok(())
     }
@@ -253,9 +242,7 @@ impl CaldavClient {
         }
         let collection = self.absolute_url(collection_href)?;
         let base = reqwest::Url::parse(&collection)?;
-        Ok(base
-            .join(&format!("{}.ics", Uuid::new_v4()))?
-            .to_string())
+        Ok(base.join(&format!("{}.ics", Uuid::new_v4()))?.to_string())
     }
 
     fn relative_href(&self, href: &str) -> String {

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -180,7 +180,11 @@ impl EasBuilder {
     fn into_item(self) -> Result<CalendarItem> {
         let start = self.start.ok_or_else(|| anyhow!("missing StartTime"))?;
         let end = self.end.ok_or_else(|| anyhow!("missing EndTime"))?;
-let uid = self.client_uid.clone().or(self.uid).unwrap_or_else(|| Uuid::new_v4().to_string());
+        let uid = self
+            .client_uid
+            .clone()
+            .or(self.uid)
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
         Ok(CalendarItem {
             uid,
             subject: self.subject.unwrap_or_else(|| "(no subject)".to_string()),
@@ -468,31 +472,29 @@ fn parse_tzid_from_key(key: &str) -> Option<String> {
     parse_ical_param(key, "TZID").map(|v| v.trim_matches('"').to_string())
 }
 
-fn parse_datetime_with_tzid(
-    val: &str,
-    tzid: Option<&str>,
-) -> Option<chrono::DateTime<Utc>> {
-    if let Some(tzid) = tzid {
-        if !val.ends_with('Z') && val.contains('T') {
-            if let Ok(local) = NaiveDateTime::parse_from_str(val, "%Y%m%dT%H%M%S") {
-                if let Ok(tz) = tzid.parse::<Tz>() {
-                    if let Some(dt) = tz.from_local_datetime(&local).single() {
-                        return Some(dt.with_timezone(&Utc));
-                    }
-                    if let Some(dt) = tz.from_local_datetime(&local).earliest() {
-                        return Some(dt.with_timezone(&Utc));
-                    }
-                }
+fn parse_datetime_with_tzid(val: &str, tzid: Option<&str>) -> Option<chrono::DateTime<Utc>> {
+    if let Some(tzid) = tzid
+        && !val.ends_with('Z')
+        && val.contains('T')
+    {
+        if let Ok(local) = NaiveDateTime::parse_from_str(val, "%Y%m%dT%H%M%S")
+            && let Ok(tz) = tzid.parse::<Tz>()
+        {
+            if let Some(dt) = tz.from_local_datetime(&local).single() {
+                return Some(dt.with_timezone(&Utc));
             }
-            if let Ok(local) = NaiveDateTime::parse_from_str(val, "%Y-%m-%dT%H:%M:%S") {
-                if let Ok(tz) = tzid.parse::<Tz>() {
-                    if let Some(dt) = tz.from_local_datetime(&local).single() {
-                        return Some(dt.with_timezone(&Utc));
-                    }
-                    if let Some(dt) = tz.from_local_datetime(&local).earliest() {
-                        return Some(dt.with_timezone(&Utc));
-                    }
-                }
+            if let Some(dt) = tz.from_local_datetime(&local).earliest() {
+                return Some(dt.with_timezone(&Utc));
+            }
+        }
+        if let Ok(local) = NaiveDateTime::parse_from_str(val, "%Y-%m-%dT%H:%M:%S")
+            && let Ok(tz) = tzid.parse::<Tz>()
+        {
+            if let Some(dt) = tz.from_local_datetime(&local).single() {
+                return Some(dt.with_timezone(&Utc));
+            }
+            if let Some(dt) = tz.from_local_datetime(&local).earliest() {
+                return Some(dt.with_timezone(&Utc));
             }
         }
     }
@@ -507,13 +509,13 @@ fn format_ical_datetime_with_timezone(
     if all_day {
         return (None, dt.format("%Y%m%d").to_string());
     }
-    if let Some(tzid) = timezone {
-        if let Ok(tz) = tzid.parse::<Tz>() {
-            return (
-                Some(tzid.to_string()),
-                dt.with_timezone(&tz).format("%Y%m%dT%H%M%S").to_string(),
-            );
-        }
+    if let Some(tzid) = timezone
+        && let Ok(tz) = tzid.parse::<Tz>()
+    {
+        return (
+            Some(tzid.to_string()),
+            dt.with_timezone(&tz).format("%Y%m%dT%H%M%S").to_string(),
+        );
     }
     (None, dt.format("%Y%m%dT%H%M%SZ").to_string())
 }
@@ -635,13 +637,11 @@ fn parse_event_lines(lines: &[String]) -> CalendarEventFields {
                 fields.attendees.push(Attendee {
                     name,
                     email: email.unwrap_or_default(),
-                    attendee_type: parse_ical_param(k, "ROLE").map(|role| {
-                        match role.as_str() {
-                            "REQ-PARTICIPANT" => 1,
-                            "OPT-PARTICIPANT" => 2,
-                            "NON-PARTICIPANT" => 3,
-                            _ => 1,
-                        }
+                    attendee_type: parse_ical_param(k, "ROLE").map(|role| match role.as_str() {
+                        "REQ-PARTICIPANT" => 1,
+                        "OPT-PARTICIPANT" => 2,
+                        "NON-PARTICIPANT" => 3,
+                        _ => 1,
                     }),
                     attendee_status: partstat.as_deref().map(partstat_to_status),
                     partstat,
@@ -653,8 +653,11 @@ fn parse_event_lines(lines: &[String]) -> CalendarEventFields {
             "CLASS" => fields.sensitivity = class_to_sensitivity(value),
             "STATUS" if value.eq_ignore_ascii_case("CANCELLED") => fields.deleted = true,
             "TRANSP" => {
-                fields.busy_status =
-                    Some(if value.eq_ignore_ascii_case("TRANSPARENT") { 0 } else { 2 });
+                fields.busy_status = Some(if value.eq_ignore_ascii_case("TRANSPARENT") {
+                    0
+                } else {
+                    2
+                });
             }
             "X-MICROSOFT-CDO-BUSYSTATUS" => fields.busy_status = value.parse().ok(),
             "X-MICROSOFT-CDO-ALLDAYEVENT" => fields.all_day = Some(value == "TRUE"),
@@ -666,9 +669,7 @@ fn parse_event_lines(lines: &[String]) -> CalendarEventFields {
                 fields.online_meeting_external_link = Some(value.to_string())
             }
             "X-MS-RESPONSE-REQUESTED" => fields.response_requested = Some(value == "TRUE"),
-            "X-MS-DISALLOW-COUNTER" => {
-                fields.disallow_new_time_proposal = Some(value == "TRUE")
-            }
+            "X-MS-DISALLOW-COUNTER" => fields.disallow_new_time_proposal = Some(value == "TRUE"),
             "X-MS-MEETING-STATUS" => fields.meeting_status = value.parse().ok(),
             "X-MS-RESPONSE-TYPE" => fields.response_type = value.parse().ok(),
             "X-MS-CLIENT-UID" => fields.client_uid = Some(value.to_string()),
@@ -856,10 +857,7 @@ pub fn render_ics(item: &CalendarItem) -> String {
         dtend_line,
     ]);
     if !item.location.is_empty() {
-        lines.push(format!(
-            "LOCATION:{}",
-            escape_ical_text(&item.location)
-        ));
+        lines.push(format!("LOCATION:{}", escape_ical_text(&item.location)));
     }
     if !item.description.is_empty() {
         lines.push(format!(
@@ -983,10 +981,10 @@ pub fn render_ics(item: &CalendarItem) -> String {
     if let Some(v) = &item.client_uid {
         lines.push(format!("X-MS-CLIENT-UID:{}", escape_ical_text(v)));
     }
-    if !item.all_day {
-        if let Some(v) = &item.timezone {
-            lines.push(format!("X-EAS-TIMEZONE:{}", escape_ical_text(v)));
-        }
+    if !item.all_day
+        && let Some(v) = &item.timezone
+    {
+        lines.push(format!("X-EAS-TIMEZONE:{}", escape_ical_text(v)));
     }
     lines.push("END:VEVENT".to_string());
 
@@ -994,10 +992,9 @@ pub fn render_ics(item: &CalendarItem) -> String {
         let base_duration = item.end - item.start;
         let effective_all_day = exception.all_day.unwrap_or(item.all_day);
         let effective_start = exception.start.unwrap_or(exception.exception_start);
-        let effective_end =
-            exception
-                .end
-                .unwrap_or_else(|| effective_start + base_duration);
+        let effective_end = exception
+            .end
+            .unwrap_or_else(|| effective_start + base_duration);
         lines.push("BEGIN:VEVENT".to_string());
         lines.push(format!("UID:{uid}"));
         lines.push(format!("DTSTAMP:{dtstamp}"));
@@ -1045,25 +1042,14 @@ pub fn render_ics(item: &CalendarItem) -> String {
         });
         lines.push(format!(
             "SUMMARY:{}",
-            escape_ical_text(
-                exception
-                    .subject
-                    .as_deref()
-                    .unwrap_or(&item.subject)
-            )
+            escape_ical_text(exception.subject.as_deref().unwrap_or(&item.subject))
         ));
-        if let Some(location) = exception
-            .location
-            .as_deref()
-            .or(Some(&item.location))
+        if let Some(location) = exception.location.as_deref().or(Some(&item.location))
             && !location.is_empty()
         {
             lines.push(format!("LOCATION:{}", escape_ical_text(location)));
         }
-        if let Some(description) = exception
-            .description
-            .as_deref()
-            .or(Some(&item.description))
+        if let Some(description) = exception.description.as_deref().or(Some(&item.description))
             && !description.is_empty()
         {
             lines.push(format!("DESCRIPTION:{}", escape_ical_text(description)));
@@ -1276,9 +1262,7 @@ pub fn parse_eas_sync_mutations(xml: &str) -> Result<Vec<EasSyncMutation>> {
                             }
                         }
                         Some(b"DisplayName")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Location") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Location") =>
                         {
                             if let Some(ex) = current.current_exception.as_mut() {
                                 ex.location = Some(value);
@@ -1374,30 +1358,20 @@ pub fn parse_eas_sync_mutations(xml: &str) -> Result<Vec<EasSyncMutation>> {
                                 current.categories.push(value);
                             }
                         }
-                        Some(b"Name")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Attendee") =>
-                        {
+                        Some(b"Name") if stack.iter().any(|v| v.as_slice() == b"Attendee") => {
                             current
                                 .current_attendee
                                 .get_or_insert_with(Attendee::default)
                                 .name = Some(value);
                         }
-                        Some(b"Email")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Attendee") =>
-                        {
+                        Some(b"Email") if stack.iter().any(|v| v.as_slice() == b"Attendee") => {
                             current
                                 .current_attendee
                                 .get_or_insert_with(Attendee::default)
                                 .email = value;
                         }
                         Some(b"AttendeeType")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Attendee") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Attendee") =>
                         {
                             current
                                 .current_attendee
@@ -1405,9 +1379,7 @@ pub fn parse_eas_sync_mutations(xml: &str) -> Result<Vec<EasSyncMutation>> {
                                 .attendee_type = value.parse().ok();
                         }
                         Some(b"AttendeeStatus")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Attendee") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Attendee") =>
                         {
                             let attendee = current
                                 .current_attendee
@@ -1416,101 +1388,69 @@ pub fn parse_eas_sync_mutations(xml: &str) -> Result<Vec<EasSyncMutation>> {
                             attendee.attendee_status = status;
                             attendee.partstat = status.map(status_to_partstat);
                         }
-                        Some(b"Deleted")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Exception") =>
-                        {
+                        Some(b"Deleted") if stack.iter().any(|v| v.as_slice() == b"Exception") => {
                             if let Some(ex) = current.current_exception.as_mut() {
                                 ex.deleted = value == "1";
                             }
                         }
                         Some(b"ExceptionStartTime")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Exception") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Exception") =>
                         {
                             if let Some(ex) = current.current_exception.as_mut() {
                                 ex.exception_start = parse_datetime(&value)
                                     .ok_or_else(|| anyhow!("invalid ExceptionStartTime"))?;
                             }
                         }
-                        Some(b"Data")
-                            if stack.iter().any(|v| v.as_slice() == b"Body") =>
-                        {
+                        Some(b"Data") if stack.iter().any(|v| v.as_slice() == b"Body") => {
                             if let Some(ex) = current.current_exception.as_mut() {
                                 ex.description = Some(value);
                             } else {
                                 current.description = Some(value);
                             }
                         }
-                        Some(b"Type")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
-                        {
+                        Some(b"Type") if stack.iter().any(|v| v.as_slice() == b"Recurrence") => {
                             current.recurrence.kind = value.parse().ok()
                         }
                         Some(b"Interval")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.interval = value.parse().ok()
                         }
                         Some(b"DayOfWeek")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.day_of_week = Some(value)
                         }
                         Some(b"DayOfMonth")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.day_of_month = value.parse().ok()
                         }
                         Some(b"WeekOfMonth")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.week_of_month = value.parse().ok()
                         }
                         Some(b"MonthOfYear")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.month_of_year = value.parse().ok()
                         }
-                        Some(b"Until")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
-                        {
+                        Some(b"Until") if stack.iter().any(|v| v.as_slice() == b"Recurrence") => {
                             current.recurrence.until = Some(value)
                         }
                         Some(b"Occurrences")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.occurrences = value.parse().ok()
                         }
                         Some(b"FirstDayOfWeek")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.first_day_of_week = value.parse().ok()
                         }
                         Some(b"CalendarType")
-                            if stack
-                                .iter()
-                                .any(|v| v.as_slice() == b"Recurrence") =>
+                            if stack.iter().any(|v| v.as_slice() == b"Recurrence") =>
                         {
                             current.recurrence.calendar_type = value.parse().ok()
                         }
@@ -1535,40 +1475,37 @@ pub fn parse_eas_sync_mutations(xml: &str) -> Result<Vec<EasSyncMutation>> {
                 {
                     current.exceptions.push(exception);
                 }
-                if matches!(
-                    name.as_slice(),
-                    b"Add" | b"Change" | b"Delete"
-                ) {
+                if matches!(name.as_slice(), b"Add" | b"Change" | b"Delete") {
                     match current_kind.take() {
-                Some(EasOpKind::Add) => {
-                    let client_id = current.client_id.clone();
-                    let builder = std::mem::take(&mut current);
-                    out.push(EasSyncMutation::Add {
-                        client_id,
-                        item: builder.into_item()?,
-                    });
-                }
-                Some(EasOpKind::Change) => {
-                    let server_id = current.server_id.clone().unwrap_or_default();
-                    let instance_id = current.instance_id.clone();
-                    let builder = std::mem::take(&mut current);
-                    out.push(EasSyncMutation::Change {
-                        server_id,
-                        instance_id,
-                        patch: builder.into_patch(),
-                    });
-                }
-                Some(EasOpKind::Delete) => {
-                    let server_id = current.server_id.clone().unwrap_or_default();
-                    let instance_id = current.instance_id.clone();
-                    let _builder = std::mem::take(&mut current);
-                    out.push(EasSyncMutation::Delete {
-                        server_id,
-                        instance_id,
-                    });
-                }
-                None => {}
-            }
+                        Some(EasOpKind::Add) => {
+                            let client_id = current.client_id.clone();
+                            let builder = std::mem::take(&mut current);
+                            out.push(EasSyncMutation::Add {
+                                client_id,
+                                item: builder.into_item()?,
+                            });
+                        }
+                        Some(EasOpKind::Change) => {
+                            let server_id = current.server_id.clone().unwrap_or_default();
+                            let instance_id = current.instance_id;
+                            let builder = std::mem::take(&mut current);
+                            out.push(EasSyncMutation::Change {
+                                server_id,
+                                instance_id,
+                                patch: builder.into_patch(),
+                            });
+                        }
+                        Some(EasOpKind::Delete) => {
+                            let server_id = current.server_id.clone().unwrap_or_default();
+                            let instance_id = current.instance_id;
+                            let _builder = std::mem::take(&mut current);
+                            out.push(EasSyncMutation::Delete {
+                                server_id,
+                                instance_id,
+                            });
+                        }
+                        None => {}
+                    }
                 }
                 stack.pop();
             }
@@ -1694,9 +1631,11 @@ pub fn parse_ews_recurrence(xml: &str) -> Option<String> {
                 ];
                 let byday: Vec<&str> = mapping
                     .iter()
-                    .filter_map(|(bit, code)| {
-                        if value & bit != 0 { Some(*code) } else { None }
-                    })
+                    .filter_map(
+                        |(bit, code)| {
+                            if value & bit != 0 { Some(*code) } else { None }
+                        },
+                    )
                     .collect();
                 if !byday.is_empty() {
                     parts.push(format!("BYDAY={}", byday.join(",")));
@@ -1742,9 +1681,7 @@ pub fn parse_ews_recurrence(xml: &str) -> Option<String> {
         }
     } else if xml.contains("AbsoluteYearlyRecurrence") {
         parts.push("FREQ=YEARLY".to_string());
-        if let Some(month) =
-            extract_ews_field(xml, b"Month").and_then(|v| parse_ews_month(&v))
-        {
+        if let Some(month) = extract_ews_field(xml, b"Month").and_then(|v| parse_ews_month(&v)) {
             parts.push(format!("BYMONTH={month}"));
         }
         if let Some(day) = extract_ews_field(xml, b"DayOfMonth") {
@@ -1752,9 +1689,7 @@ pub fn parse_ews_recurrence(xml: &str) -> Option<String> {
         }
     } else if xml.contains("RelativeYearlyRecurrence") {
         parts.push("FREQ=YEARLY".to_string());
-        if let Some(month) =
-            extract_ews_field(xml, b"Month").and_then(|v| parse_ews_month(&v))
-        {
+        if let Some(month) = extract_ews_field(xml, b"Month").and_then(|v| parse_ews_month(&v)) {
             parts.push(format!("BYMONTH={month}"));
         }
         if let Some(days) = extract_ews_field(xml, b"DaysOfWeek") {
@@ -1783,13 +1718,9 @@ pub fn parse_ews_recurrence(xml: &str) -> Option<String> {
     }
     if let Some(count) = extract_ews_field(xml, b"NumberOfOccurrences") {
         parts.push(format!("COUNT={count}"));
-    } else if let Some(until) =
-        extract_ews_field(xml, b"EndDate").and_then(|v| parse_datetime(&v))
+    } else if let Some(until) = extract_ews_field(xml, b"EndDate").and_then(|v| parse_datetime(&v))
     {
-        parts.push(format!(
-            "UNTIL={}",
-            until.format("%Y%m%dT%H%M%SZ")
-        ));
+        parts.push(format!("UNTIL={}", until.format("%Y%m%dT%H%M%SZ")));
     }
     Some(parts.join(";"))
 }
@@ -1820,11 +1751,7 @@ pub fn parse_ews_attendees(xml: &str) -> Vec<Attendee> {
             }
             Ok(Event::Text(t)) => {
                 if let Some(attendee) = current.as_mut() {
-                    let value = t
-                        .decode()
-                        .ok()
-                        .map(|v| v.into_owned())
-                        .unwrap_or_default();
+                    let value = t.decode().ok().map(|v| v.into_owned()).unwrap_or_default();
                     match stack.last().map(|v| v.as_slice()) {
                         Some(b"Name") => attendee.name = Some(value),
                         Some(b"EmailAddress") => attendee.email = value,
@@ -1849,10 +1776,7 @@ pub fn parse_ews_attendees(xml: &str) -> Vec<Attendee> {
                     && !attendee.email.is_empty()
                 {
                     attendees.push(attendee);
-                } else if matches!(
-                    name.as_slice(),
-                    b"RequiredAttendees" | b"OptionalAttendees"
-                ) {
+                } else if matches!(name.as_slice(), b"RequiredAttendees" | b"OptionalAttendees") {
                     attendee_type = None;
                 }
                 stack.pop();
@@ -1867,8 +1791,7 @@ pub fn parse_ews_attendees(xml: &str) -> Vec<Attendee> {
 }
 
 pub fn parse_ews_calendar_item(xml: &str) -> Result<CalendarItem> {
-    let subject = extract_ews_field(xml, b"Subject")
-        .unwrap_or_else(|| "(no subject)".to_string());
+    let subject = extract_ews_field(xml, b"Subject").unwrap_or_else(|| "(no subject)".to_string());
     let start = extract_ews_field(xml, b"Start")
         .or_else(|| extract_ews_field(xml, b"StartTime"))
         .and_then(|v| parse_datetime(&v))
@@ -1891,8 +1814,8 @@ pub fn parse_ews_calendar_item(xml: &str) -> Result<CalendarItem> {
     let organizer_email = extract_ews_field(xml, b"OrganizerEmail");
     let categories = extract_ews_fields(xml, b"String");
     let attendees = parse_ews_attendees(xml);
-    let reminder = extract_ews_field(xml, b"ReminderMinutesBeforeStart")
-        .and_then(|v| v.parse().ok());
+    let reminder =
+        extract_ews_field(xml, b"ReminderMinutesBeforeStart").and_then(|v| v.parse().ok());
     let busy_status =
         extract_ews_field(xml, b"LegacyFreeBusyStatus").and_then(|v| match v.as_str() {
             "Free" => Some(0),
@@ -1901,21 +1824,19 @@ pub fn parse_ews_calendar_item(xml: &str) -> Result<CalendarItem> {
             "OOF" => Some(3),
             _ => None,
         });
-    let sensitivity =
-        extract_ews_field(xml, b"Sensitivity").and_then(|v| match v.as_str() {
-            "Normal" => Some(0),
-            "Personal" => Some(1),
-            "Private" => Some(2),
-            "Confidential" => Some(3),
-            _ => None,
-        });
-    let response_requested = extract_ews_field(xml, b"ResponseRequested")
-        .map(|v| v.eq_ignore_ascii_case("true"));
-    let disallow_new_time_proposal = extract_ews_field(xml, b"DisallowNewTimeProposal")
-        .map(|v| v.eq_ignore_ascii_case("true"));
+    let sensitivity = extract_ews_field(xml, b"Sensitivity").and_then(|v| match v.as_str() {
+        "Normal" => Some(0),
+        "Personal" => Some(1),
+        "Private" => Some(2),
+        "Confidential" => Some(3),
+        _ => None,
+    });
+    let response_requested =
+        extract_ews_field(xml, b"ResponseRequested").map(|v| v.eq_ignore_ascii_case("true"));
+    let disallow_new_time_proposal =
+        extract_ews_field(xml, b"DisallowNewTimeProposal").map(|v| v.eq_ignore_ascii_case("true"));
     let online_meeting_conf_link = extract_ews_field(xml, b"OnlineMeetingConfLink");
-    let online_meeting_external_link =
-        extract_ews_field(xml, b"OnlineMeetingExternalLink");
+    let online_meeting_external_link = extract_ews_field(xml, b"OnlineMeetingExternalLink");
     let client_uid = extract_ews_field(xml, b"ClientUid");
     let rrule = parse_ews_recurrence(xml);
 
@@ -1954,8 +1875,8 @@ pub fn parse_ews_calendar_item(xml: &str) -> Result<CalendarItem> {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_datetime, parse_eas_sync_mutations, parse_ews_attendees,
-        parse_ews_recurrence, parse_ics_event, render_ics, EasRecurrence,
+        EasRecurrence, parse_eas_sync_mutations, parse_ews_attendees, parse_ews_recurrence,
+        parse_ics_event, render_ics,
     };
 
     #[test]
@@ -1979,7 +1900,11 @@ mod tests {
         let items = parse_eas_sync_mutations(xml).unwrap();
         assert_eq!(items.len(), 1);
         match &items[0] {
-            super::EasSyncMutation::Change { server_id, instance_id, .. } => {
+            super::EasSyncMutation::Change {
+                server_id,
+                instance_id,
+                ..
+            } => {
                 assert_eq!(server_id, "abc123");
                 assert!(instance_id.is_some());
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,8 @@
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::fs;
-use zeroize::Zeroizing;
 use url::Url;
+use zeroize::Zeroizing;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
@@ -29,8 +29,8 @@ impl Config {
         cfg.validate()?;
 
         if cfg.gateway_host.is_empty() {
-            cfg.gateway_host = extract_host_from_url(&cfg.worker_url)
-                .unwrap_or_else(|| "localhost".to_string());
+            cfg.gateway_host =
+                extract_host_from_url(&cfg.worker_url).unwrap_or_else(|| "localhost".to_string());
         }
 
         Ok(cfg)
@@ -49,7 +49,9 @@ impl Config {
             return Err(anyhow::anyhow!("Config: 'bind' address is required"));
         }
         if !self.bind.contains(':') {
-            return Err(anyhow::anyhow!("Config: 'bind' must be in format 'host:port'"));
+            return Err(anyhow::anyhow!(
+                "Config: 'bind' must be in format 'host:port'"
+            ));
         }
         if self.caldav_base.is_empty() {
             return Err(anyhow::anyhow!("Config: 'caldav_base' URL is required"));
@@ -65,7 +67,9 @@ impl Config {
             return Err(anyhow::anyhow!("Config: 'worker_secret' is required"));
         }
         if self.worker_secret.expose_secret().len() < 16 {
-            tracing::warn!("Config: worker_secret is shorter than 16 characters — this is insecure");
+            tracing::warn!(
+                "Config: worker_secret is shorter than 16 characters — this is insecure"
+            );
         }
 
         if self.hmac_secret.expose_secret().is_empty() {
@@ -117,7 +121,14 @@ fn validate_url(url: &str, field_name: &str) -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
-    fn make_config(bind: &str, caldav_base: &str, worker_url: &str, worker_secret: &str, hmac_secret: &str, gateway_host: &str) -> Config {
+    fn make_config(
+        bind: &str,
+        caldav_base: &str,
+        worker_url: &str,
+        worker_secret: &str,
+        hmac_secret: &str,
+        gateway_host: &str,
+    ) -> Config {
         Config {
             bind: bind.into(),
             caldav_base: caldav_base.into(),
@@ -151,25 +162,53 @@ mod tests {
 
     #[test]
     fn validates_empty_bind_fails() {
-        let cfg = make_config("", "http://localhost", "https://worker.example.com/api", "secret1234567890", "12345678901234567890123456789012", "");
+        let cfg = make_config(
+            "",
+            "http://localhost",
+            "https://worker.example.com/api",
+            "secret1234567890",
+            "12345678901234567890123456789012",
+            "",
+        );
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn validates_missing_scheme_fails() {
-        let cfg = make_config("0.0.0.0:8134", "not-a-url", "https://worker.example.com/api", "secret1234567890", "12345678901234567890123456789012", "");
+        let cfg = make_config(
+            "0.0.0.0:8134",
+            "not-a-url",
+            "https://worker.example.com/api",
+            "secret1234567890",
+            "12345678901234567890123456789012",
+            "",
+        );
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn validates_weak_secret_warns() {
-        let cfg = make_config("0.0.0.0:8134", "http://localhost", "https://worker.example.com/api", "short", "12345678901234567890123456789012", "");
+        let cfg = make_config(
+            "0.0.0.0:8134",
+            "http://localhost",
+            "https://worker.example.com/api",
+            "short",
+            "12345678901234567890123456789012",
+            "",
+        );
         let _ = cfg.validate();
     }
 
     #[test]
     fn gateway_host_with_scheme_fails() {
-        let cfg = make_config("0.0.0.0:8134", "http://localhost", "https://worker.example.com/api", "secret1234567890", "12345678901234567890123456789012", "https://exchange.example.com");
+        let cfg = make_config(
+            "0.0.0.0:8134",
+            "http://localhost",
+            "https://worker.example.com/api",
+            "secret1234567890",
+            "12345678901234567890123456789012",
+            "https://exchange.example.com",
+        );
         assert!(cfg.validate().is_err());
     }
 }

--- a/src/eas.rs
+++ b/src/eas.rs
@@ -16,7 +16,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use lru::LruCache;
 use quick_xml::Reader;
 use quick_xml::events::Event;
-use secrecy::{SecretString, ExposeSecret};
+use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, LazyLock};
@@ -43,10 +43,14 @@ type DeviceWindowCache = LruCache<String, Vec<Instant>>;
 type PingCache = LruCache<String, PingCacheEntry>;
 
 static DEVICE_WINDOW: LazyLock<TokioMutex<DeviceWindowCache>> = LazyLock::new(|| {
-    TokioMutex::new(LruCache::new(NonZeroUsize::new(MAX_DEVICE_WINDOW_ENTRIES).unwrap()))
+    TokioMutex::new(LruCache::new(
+        NonZeroUsize::new(MAX_DEVICE_WINDOW_ENTRIES).unwrap(),
+    ))
 });
 static PING_CACHE: LazyLock<TokioMutex<PingCache>> = LazyLock::new(|| {
-    TokioMutex::new(LruCache::new(NonZeroUsize::new(MAX_PING_CACHE_ENTRIES).unwrap()))
+    TokioMutex::new(LruCache::new(
+        NonZeroUsize::new(MAX_PING_CACHE_ENTRIES).unwrap(),
+    ))
 });
 
 #[derive(Clone, Debug)]
@@ -173,30 +177,36 @@ fn validate_payload(command: &str, xml: &str) -> Result<(), &'static str> {
                 let name = String::from_utf8_lossy(e.name().local_name().as_ref()).to_string();
                 let qname = e.name();
                 let qname_bytes = qname.as_ref();
-                
+
                 // Determine the root element's namespace correctly:
                 // - For unprefixed elements (e.g., <Sync>): use the default namespace (xmlns="...")
                 // - For prefixed elements (e.g., <as:Sync>): use the namespace bound to that prefix (xmlns:as="...")
                 let ns = if let Some(colon_pos) = qname_bytes.iter().position(|&b| b == b':') {
                     // Prefixed element: find the namespace bound to this prefix
                     let prefix = &qname_bytes[..colon_pos];
-                    e.attributes().flatten().find_map(|attr| {
-                        let key = attr.key.as_ref();
-                        if key.starts_with(b"xmlns:") && &key[6..] == prefix {
-                            Some(String::from_utf8_lossy(attr.value.as_ref()).to_string())
-                        } else {
-                            None
-                        }
-                    }).unwrap_or_default()
+                    e.attributes()
+                        .flatten()
+                        .find_map(|attr| {
+                            let key = attr.key.as_ref();
+                            if key.starts_with(b"xmlns:") && &key[6..] == prefix {
+                                Some(String::from_utf8_lossy(attr.value.as_ref()).to_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_default()
                 } else {
                     // Unprefixed element: use the default namespace (xmlns="...")
-                    e.attributes().flatten().find_map(|attr| {
-                        if attr.key.as_ref() == b"xmlns" {
-                            Some(String::from_utf8_lossy(attr.value.as_ref()).to_string())
-                        } else {
-                            None
-                        }
-                    }).unwrap_or_default()
+                    e.attributes()
+                        .flatten()
+                        .find_map(|attr| {
+                            if attr.key.as_ref() == b"xmlns" {
+                                Some(String::from_utf8_lossy(attr.value.as_ref()).to_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_default()
                 };
                 break (name, ns);
             }
@@ -221,10 +231,10 @@ fn validate_payload(command: &str, xml: &str) -> Result<(), &'static str> {
 
     match lower_cmd.as_str() {
         "sync" => {
-            if let Some(class) = extract_first_tag_text(xml, b"Class") {
-                if !class.eq_ignore_ascii_case("Calendar") {
-                    return Err("Only Calendar Sync class is supported");
-                }
+            if let Some(class) = extract_first_tag_text(xml, b"Class")
+                && !class.eq_ignore_ascii_case("Calendar")
+            {
+                return Err("Only Calendar Sync class is supported");
             }
             if xml.contains("<Add>") && !xml.contains("<ClientId>") {
                 return Err("Add requires ClientId");
@@ -266,10 +276,7 @@ fn extract_root_command(xml: &str) -> Option<String> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) | Ok(Event::Empty(e)) => {
-                return Some(
-                    String::from_utf8_lossy(e.name().local_name().as_ref())
-                        .to_string(),
-                );
+                return Some(String::from_utf8_lossy(e.name().local_name().as_ref()).to_string());
             }
             Ok(Event::Eof) | Err(_) => return None,
             _ => {}
@@ -285,15 +292,9 @@ fn extract_first_tag_text(xml: &str, tag: &[u8]) -> Option<String> {
     let mut inside = false;
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.name().local_name().as_ref() == tag => {
-                inside = true
-            }
-            Ok(Event::Text(t)) if inside => {
-                return t.decode().ok().map(|v| v.into_owned())
-            }
-            Ok(Event::End(e)) if e.name().local_name().as_ref() == tag => {
-                inside = false
-            }
+            Ok(Event::Start(e)) if e.name().local_name().as_ref() == tag => inside = true,
+            Ok(Event::Text(t)) if inside => return t.decode().ok().map(|v| v.into_owned()),
+            Ok(Event::End(e)) if e.name().local_name().as_ref() == tag => inside = false,
             Ok(Event::Eof) | Err(_) => return None,
             _ => {}
         }
@@ -309,17 +310,13 @@ fn extract_all_tag_text(xml: &str, tag: &[u8]) -> Vec<String> {
     let mut values = Vec::new();
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.name().local_name().as_ref() == tag => {
-                inside = true
-            }
+            Ok(Event::Start(e)) if e.name().local_name().as_ref() == tag => inside = true,
             Ok(Event::Text(t)) if inside => {
                 if let Ok(v) = t.decode() {
                     values.push(v.into_owned());
                 }
             }
-            Ok(Event::End(e)) if e.name().local_name().as_ref() == tag => {
-                inside = false
-            }
+            Ok(Event::End(e)) if e.name().local_name().as_ref() == tag => inside = false,
             Ok(Event::Eof) | Err(_) => break,
             _ => {}
         }
@@ -352,31 +349,23 @@ fn parse_ping_folders(xml: &str) -> Vec<PingFolder> {
     let mut folders = Vec::new();
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e))
-                if e.name().local_name().as_ref() == b"Folder" =>
-            {
+            Ok(Event::Start(e)) if e.name().local_name().as_ref() == b"Folder" => {
                 in_folder = true;
                 current_id = None;
                 current_class = None;
             }
-            Ok(Event::Start(e))
-                if in_folder && e.name().local_name().as_ref() == b"Id" =>
-            {
+            Ok(Event::Start(e)) if in_folder && e.name().local_name().as_ref() == b"Id" => {
                 if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) {
                     current_id = t.decode().ok().map(|v| v.into_owned());
                 }
             }
-            Ok(Event::Start(e))
-                if in_folder && e.name().local_name().as_ref() == b"Class" =>
-            {
+            Ok(Event::Start(e)) if in_folder && e.name().local_name().as_ref() == b"Class" => {
                 if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) {
                     current_class = t.decode().ok().map(|v| v.into_owned());
                 }
             }
             Ok(Event::End(e)) if e.name().local_name().as_ref() == b"Folder" => {
-                if let (Some(id), Some(class_name)) =
-                    (current_id.take(), current_class.take())
-                {
+                if let (Some(id), Some(class_name)) = (current_id.take(), current_class.take()) {
                     folders.push(PingFolder { id, class_name });
                 }
                 in_folder = false;
@@ -398,9 +387,7 @@ fn parse_item_operations_fetches(xml: &str) -> Vec<ItemOperationsFetch> {
     let mut current_tag: Option<Vec<u8>> = None;
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e))
-                if e.name().local_name().as_ref() == b"Fetch" =>
-            {
+            Ok(Event::Start(e)) if e.name().local_name().as_ref() == b"Fetch" => {
                 current = Some(ItemOperationsFetch::default());
                 current_tag = None;
             }
@@ -408,11 +395,7 @@ fn parse_item_operations_fetches(xml: &str) -> Vec<ItemOperationsFetch> {
                 current_tag = Some(e.name().local_name().as_ref().to_vec());
             }
             Ok(Event::Text(t)) if current.is_some() => {
-                let text = t
-                    .decode()
-                    .ok()
-                    .map(|v| v.into_owned())
-                    .unwrap_or_default();
+                let text = t.decode().ok().map(|v| v.into_owned()).unwrap_or_default();
                 if let Some(fetch) = current.as_mut() {
                     match current_tag.as_deref() {
                         Some(b"Store") => fetch.store = text,
@@ -439,17 +422,14 @@ fn parse_item_operations_fetches(xml: &str) -> Vec<ItemOperationsFetch> {
 }
 
 fn parse_search_request(xml: &str) -> SearchRequest {
-    let range = extract_first_tag_text(xml, b"Range")
-        .unwrap_or_else(|| "0-9".to_string());
+    let range = extract_first_tag_text(xml, b"Range").unwrap_or_else(|| "0-9".to_string());
     let (range_start, range_end) = range
         .split_once('-')
         .and_then(|(s, e)| Some((s.trim().parse().ok()?, e.trim().parse().ok()?)))
         .unwrap_or((0, 9));
     SearchRequest {
-        store_name: extract_first_tag_text(xml, b"Name")
-            .unwrap_or_else(|| "Mailbox".to_string()),
-        query_text: extract_first_tag_text(xml, b"Query")
-            .map(|v| v.trim().to_string()),
+        store_name: extract_first_tag_text(xml, b"Name").unwrap_or_else(|| "Mailbox".to_string()),
+        query_text: extract_first_tag_text(xml, b"Query").map(|v| v.trim().to_string()),
         range_start,
         range_end,
         starts: extract_first_tag_text(xml, b"Starts")
@@ -469,10 +449,7 @@ fn active_user_emails(username: &str) -> Vec<String> {
     emails
 }
 
-fn matches_search(
-    item: &crate::calendar::CalendarItem,
-    query: Option<&str>,
-) -> bool {
+fn matches_search(item: &crate::calendar::CalendarItem, query: Option<&str>) -> bool {
     let Some(query) = query.map(str::trim).filter(|v| !v.is_empty()) else {
         return true;
     };
@@ -532,8 +509,7 @@ fn parse_request(query: &HashMap<String, String>, xml: &str, headers: &HeaderMap
     let get_changes = extract_first_tag_text(xml, b"GetChanges")
         .map(|v| v.trim() != "0")
         .unwrap_or(true);
-    let filter_type = extract_first_tag_text(xml, b"FilterType")
-        .and_then(|v| v.parse::<u8>().ok());
+    let filter_type = extract_first_tag_text(xml, b"FilterType").and_then(|v| v.parse::<u8>().ok());
 
     let protocol_version = headers
         .get("MS-ASProtocolVersion")
@@ -582,11 +558,8 @@ async fn maybe_throttle(owner: &str, device_id: &str) -> bool {
     let key = format!("{}:{}", owner, device_id);
     let now = Instant::now();
     let mut cache = DEVICE_WINDOW.lock().await;
-    let entries = cache.get_or_insert_mut(key, || Vec::new());
-    entries.retain(|ts| {
-        now.checked_duration_since(*ts)
-            .map_or(false, |d| d < WINDOW)
-    });
+    let entries = cache.get_or_insert_mut(key, Vec::new);
+    entries.retain(|ts| now.checked_duration_since(*ts).is_some_and(|d| d < WINDOW));
     if entries.len() >= MAX_REQUESTS_PER_WINDOW {
         return true;
     }
@@ -596,23 +569,11 @@ async fn maybe_throttle(owner: &str, device_id: &str) -> bool {
 
 fn inject_common_headers(resp: &mut Response, request_id: &str) {
     let h = resp.headers_mut();
-    h.insert(
-        "MS-Server-ActiveSync",
-        "16.1".parse().unwrap(),
-    );
-    h.insert(
-        "X-MS-ProtocolVersion",
-        "16.1".parse().unwrap(),
-    );
-    h.insert(
-        "Cache-Control",
-        "private, no-store".parse().unwrap(),
-    );
+    h.insert("MS-Server-ActiveSync", "16.1".parse().unwrap());
+    h.insert("X-MS-ProtocolVersion", "16.1".parse().unwrap());
+    h.insert("Cache-Control", "private, no-store".parse().unwrap());
     h.insert("Pragma", "no-cache".parse().unwrap());
-    h.insert(
-        "X-Request-Id",
-        request_id.parse().unwrap(),
-    );
+    h.insert("X-Request-Id", request_id.parse().unwrap());
 }
 
 fn unauth_response(request_id: &str) -> Response {
@@ -677,12 +638,7 @@ fn bad_request_response(request_id: &str, msg: &str) -> Response {
     r
 }
 
-fn xml_or_wbxml_response(
-    wbxml: &Wbxml,
-    as_wbxml: bool,
-    xml: &str,
-    request_id: &str,
-) -> Response {
+fn xml_or_wbxml_response(wbxml: &Wbxml, as_wbxml: bool, xml: &str, request_id: &str) -> Response {
     let mut r = if as_wbxml {
         match wbxml.encode(xml) {
             Ok(b) => (
@@ -696,10 +652,7 @@ fn xml_or_wbxml_response(
                 .into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                [(
-                    header::CONTENT_TYPE.as_str(),
-                    "text/plain; charset=utf-8",
-                )],
+                [(header::CONTENT_TYPE.as_str(), "text/plain; charset=utf-8")],
                 format!("WBXML Encode Err: {}", e).into_bytes(),
             )
                 .into_response(),
@@ -805,12 +758,8 @@ async fn handle_provision(
         .device_id
         .clone()
         .unwrap_or_else(|| "unknown-device".to_string());
-    let incoming_key = req
-        .policy_key
-        .clone()
-        .unwrap_or_else(|| "0".to_string());
-    let (friendly_name, model, os, phone_number, imei, user_agent) =
-        parse_device_information(xml);
+    let incoming_key = req.policy_key.clone().unwrap_or_else(|| "0".to_string());
+    let (friendly_name, model, os, phone_number, imei, user_agent) = parse_device_information(xml);
     if [
         friendly_name.as_ref(),
         model.as_ref(),
@@ -862,11 +811,7 @@ async fn handle_provision(
         );
         return xml_or_wbxml_response(wbxml, as_wbxml, &response, request_id);
     }
-    let valid = match state
-        .storage
-        .get_provision_policy(owner, &device_id)
-        .await
-    {
+    let valid = match state.storage.get_provision_policy(owner, &device_id).await {
         Ok(Some((stored, _))) => stored.as_bytes().ct_eq(incoming_key.as_bytes()).into(),
         _ => false,
     };
@@ -931,11 +876,7 @@ async fn handle_folder_sync(
         }
     }
     let new_sync_key = Uuid::new_v4().simple().to_string();
-    let latest_seq = state
-        .storage
-        .get_latest_change_seq()
-        .await
-        .unwrap_or(0);
+    let latest_seq = state.storage.get_latest_change_seq().await.unwrap_or(0);
     let _ = state
         .storage
         .set_sync_key(
@@ -956,10 +897,7 @@ async fn handle_folder_sync(
     );
     let mut r = xml_or_wbxml_response(wbxml, as_wbxml, &resp_xml, request_id);
     if incoming == "0" {
-        r.headers_mut().insert(
-            "X-MS-RP",
-            "1".parse().unwrap(),
-        );
+        r.headers_mut().insert("X-MS-RP", "1".parse().unwrap());
     }
     r
 }
@@ -1096,12 +1034,11 @@ async fn handle_settings(
 ) -> Response {
     let primary_email = username.to_string();
     let mut sections = String::new();
-    let has_user_info = xml_body.contains("<UserInformation>")
-        || xml_body.contains("<UserInformation/>");
-    let has_oof =
-        xml_body.contains("<Oof>") || xml_body.contains("<Oof/>");
-    let has_device_password = xml_body.contains("<DevicePassword>")
-        || xml_body.contains("<DevicePassword/>");
+    let has_user_info =
+        xml_body.contains("<UserInformation>") || xml_body.contains("<UserInformation/>");
+    let has_oof = xml_body.contains("<Oof>") || xml_body.contains("<Oof/>");
+    let has_device_password =
+        xml_body.contains("<DevicePassword>") || xml_body.contains("<DevicePassword/>");
 
     if has_user_info || (!has_oof && !has_device_password) {
         let email_entries = active_user_emails(username)
@@ -1240,18 +1177,12 @@ async fn handle_item_operations(
 ) -> Response {
     let fetches = parse_item_operations_fetches(xml);
     if fetches.is_empty() {
-        return bad_request_response(
-            request_id,
-            "ItemOperations requires at least one Fetch",
-        );
+        return bad_request_response(request_id, "ItemOperations requires at least one Fetch");
     }
     let caldav = match CaldavClient::new(&state.cfg) {
         Ok(c) => c,
         Err(e) => {
-            return bad_request_response(
-                request_id,
-                &format!("CalDAV client init failed: {e}"),
-            )
+            return bad_request_response(request_id, &format!("CalDAV client init failed: {e}"));
         }
     };
     let mut responses = String::new();
@@ -1285,7 +1216,8 @@ async fn handle_item_operations(
                 continue;
             }
         };
-        let get_future = caldav.get_event(&lookup.resource_href, username, password.expose_secret());
+        let get_future =
+            caldav.get_event(&lookup.resource_href, username, password.expose_secret());
         let Ok(Ok((ics, _etag))) = timeout(CALDAV_TIMEOUT, get_future).await else {
             responses.push_str(&format!(
                 "<Fetch><Store>{}</Store><CollectionId>{}</CollectionId><ServerId>{}</ServerId><Status>8</Status></Fetch>",
@@ -1341,20 +1273,26 @@ async fn merged_freebusy_for_mailbox(
             return merged.into_iter().collect();
         }
     };
-    let calendars = timeout(CALDAV_TIMEOUT, caldav.find_user_calendars(mailbox, password.expose_secret()))
-        .await
-        .ok()
-        .and_then(|r| r.ok());
+    let calendars = timeout(
+        CALDAV_TIMEOUT,
+        caldav.find_user_calendars(mailbox, password.expose_secret()),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok());
     if let Some(calendars) = calendars
         && let Some(collection_href) = calendars.first()
     {
-        let query_result = timeout(CALDAV_TIMEOUT, caldav.query_events(
-            collection_href,
-            &start.format("%Y%m%dT%H%M%SZ").to_string(),
-            &end.format("%Y%m%dT%H%M%SZ").to_string(),
-            mailbox,
-            password.expose_secret(),
-        ))
+        let query_result = timeout(
+            CALDAV_TIMEOUT,
+            caldav.query_events(
+                collection_href,
+                &start.format("%Y%m%dT%H%M%SZ").to_string(),
+                &end.format("%Y%m%dT%H%M%SZ").to_string(),
+                mailbox,
+                password.expose_secret(),
+            ),
+        )
         .await
         .ok()
         .and_then(|r| r.ok());
@@ -1365,9 +1303,7 @@ async fn merged_freebusy_for_mailbox(
             let mut in_cal_data = false;
             loop {
                 match reader.read_event_into(&mut buf) {
-                    Ok(Event::Start(e))
-                        if e.name().local_name().as_ref() == b"calendar-data" =>
-                    {
+                    Ok(Event::Start(e)) if e.name().local_name().as_ref() == b"calendar-data" => {
                         in_cal_data = true;
                     }
                     Ok(Event::Text(t)) if in_cal_data => {
@@ -1381,21 +1317,16 @@ async fn merged_freebusy_for_mailbox(
                                 _ => '2',
                             };
                             for (i, slot) in merged.iter_mut().enumerate() {
-                                let ss = start
-                                    + chrono::Duration::minutes(
-                                        (i as i64) * safe_interval,
-                                    );
-                                let se = ss
-                                    + chrono::Duration::minutes(safe_interval);
+                                let ss =
+                                    start + chrono::Duration::minutes((i as i64) * safe_interval);
+                                let se = ss + chrono::Duration::minutes(safe_interval);
                                 if item.start < se && item.end > ss && sd > *slot {
                                     *slot = sd;
                                 }
                             }
                         }
                     }
-                    Ok(Event::End(e))
-                        if e.name().local_name().as_ref() == b"calendar-data" =>
-                    {
+                    Ok(Event::End(e)) if e.name().local_name().as_ref() == b"calendar-data" => {
                         in_cal_data = false;
                     }
                     Ok(Event::Eof) => break,
@@ -1510,23 +1441,27 @@ async fn load_calendar_events(
     password: &SecretString,
     start: chrono::DateTime<chrono::Utc>,
     end: chrono::DateTime<chrono::Utc>,
-) -> anyhow::Result<
-    Vec<(String, String, crate::calendar::CalendarItem)>,
-> {
+) -> anyhow::Result<Vec<(String, String, crate::calendar::CalendarItem)>> {
     let caldav = CaldavClient::new(&state.cfg)?;
-    let calendars = timeout(CALDAV_TIMEOUT, caldav.find_user_calendars(username, password.expose_secret()))
-        .await??;
+    let calendars = timeout(
+        CALDAV_TIMEOUT,
+        caldav.find_user_calendars(username, password.expose_secret()),
+    )
+    .await??;
     let collection_href = calendars
         .first()
         .ok_or_else(|| anyhow::anyhow!("no calendars found"))?
         .clone();
-    let events_xml = timeout(CALDAV_TIMEOUT, caldav.query_events(
-        &collection_href,
-        &start.format("%Y%m%dT%H%M%SZ").to_string(),
-        &end.format("%Y%m%dT%H%M%SZ").to_string(),
-        username,
-        password.expose_secret(),
-    ))
+    let events_xml = timeout(
+        CALDAV_TIMEOUT,
+        caldav.query_events(
+            &collection_href,
+            &start.format("%Y%m%dT%H%M%SZ").to_string(),
+            &end.format("%Y%m%dT%H%M%SZ").to_string(),
+            username,
+            password.expose_secret(),
+        ),
+    )
     .await??;
     let mut reader = Reader::from_str(&events_xml);
     reader.config_mut().trim_text(true);
@@ -1549,14 +1484,11 @@ async fn load_calendar_events(
                 }
                 _ => {}
             },
-            Ok(Event::End(ref e))
-                if e.name().local_name().as_ref() == b"response" =>
-            {
+            Ok(Event::End(ref e)) if e.name().local_name().as_ref() == b"response" => {
                 if !href.is_empty()
                     && let Some(item) = parse_ics_event(&ics)
                 {
-                    let server_id =
-                        sync::generate_server_id(state.cfg.hmac_secret(), &href);
+                    let server_id = sync::generate_server_id(state.cfg.hmac_secret(), &href);
                     out.push((server_id, href.clone(), item));
                 }
                 href.clear();
@@ -1590,17 +1522,13 @@ async fn handle_search(
     let end = req
         .ends
         .unwrap_or_else(|| chrono::Utc::now() + chrono::Duration::weeks(52));
-    let Ok(events) =
-        load_calendar_events(state, username, &password, start, end).await
-    else {
+    let Ok(events) = load_calendar_events(state, username, &password, start, end).await else {
         let r = r#"<?xml version="1.0" encoding="utf-8"?><Search xmlns="Search:"><Status>1</Status><Response><Store><Status>6</Status></Store></Response></Search>"#;
         return xml_or_wbxml_response(wbxml, as_wbxml, r, request_id);
     };
     let mut matches: Vec<_> = events
         .into_iter()
-        .filter(|(_, _, item)| {
-            matches_search(item, req.query_text.as_deref())
-        })
+        .filter(|(_, _, item)| matches_search(item, req.query_text.as_deref()))
         .collect();
     matches.sort_by_key(|(_, _, item)| item.start);
     let total = matches.len();
@@ -1659,10 +1587,7 @@ pub async fn handle(
 ) -> Response {
     let request_id = make_request_id();
     if !forwarded_https_enforced(&headers) {
-        return bad_request_response(
-            &request_id,
-            "x-forwarded-proto must be https",
-        );
+        return bad_request_response(&request_id, "x-forwarded-proto must be https");
     }
     if method == Method::OPTIONS {
         return options_response(&request_id);
@@ -1679,30 +1604,18 @@ pub async fn handle(
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .map(|ct| ct.to_ascii_lowercase().contains("wbxml"))
-        .unwrap_or(
-            payload
-                .first()
-                .is_some_and(|b| *b != b'<'),
-        );
+        .unwrap_or(payload.first().is_some_and(|b| *b != b'<'));
     let xml = if payload.is_empty() {
         String::new()
     } else {
         match wbxml.decode(&payload) {
             Ok(s) => s,
-            Err(e) => {
-                return bad_request_response(
-                    &request_id,
-                    &format!("Invalid body: {}", e),
-                )
-            }
+            Err(e) => return bad_request_response(&request_id, &format!("Invalid body: {}", e)),
         }
     };
     let req = parse_request(&query, &xml, &headers);
     if req.command.is_empty() {
-        return bad_request_response(
-            &request_id,
-            "Cannot determine EAS command",
-        );
+        return bad_request_response(&request_id, "Cannot determine EAS command");
     }
     if let Err(e) = validate_payload(&req.command, &xml) {
         return bad_request_response(&request_id, e);
@@ -1717,8 +1630,7 @@ pub async fn handle(
 
     match req.command.as_str() {
         "FolderSync" => {
-            handle_folder_sync(&state, &username, &req, &wbxml, wants_wbxml, &request_id)
-                .await
+            handle_folder_sync(&state, &username, &req, &wbxml, wants_wbxml, &request_id).await
         }
         "Provision" => {
             handle_provision(
@@ -1759,8 +1671,7 @@ pub async fn handle(
                 .await
                 {
                     Ok(results) => {
-                        mutation_responses =
-                            sync::render_client_mutation_responses(&results);
+                        mutation_responses = sync::render_client_mutation_responses(&results);
                     }
                     Err(e) => {
                         tracing::error!(
@@ -1769,12 +1680,7 @@ pub async fn handle(
                             e
                         );
                         let err_xml = r#"<?xml version="1.0" encoding="utf-8"?><Sync xmlns="AirSync:"><Status>6</Status></Sync>"#;
-                        return xml_or_wbxml_response(
-                            &wbxml,
-                            wants_wbxml,
-                            err_xml,
-                            &request_id,
-                        );
+                        return xml_or_wbxml_response(&wbxml, wants_wbxml, err_xml, &request_id);
                     }
                 }
             }
@@ -1784,9 +1690,7 @@ pub async fn handle(
                 filter_start: req
                     .filter_type
                     .map(filter_type_to_start)
-                    .unwrap_or_else(|| {
-                        chrono::Utc::now() - chrono::Duration::weeks(52)
-                    }),
+                    .unwrap_or_else(|| chrono::Utc::now() - chrono::Duration::weeks(52)),
             };
             match sync::perform_sync(
                 state,
@@ -1802,15 +1706,9 @@ pub async fn handle(
             )
             .await
             {
-                Ok(resp_xml) => {
-                    xml_or_wbxml_response(&wbxml, wants_wbxml, &resp_xml, &request_id)
-                }
+                Ok(resp_xml) => xml_or_wbxml_response(&wbxml, wants_wbxml, &resp_xml, &request_id),
                 Err(e) => {
-                    tracing::error!(
-                        "request_id={} Sync Error: {}",
-                        request_id,
-                        e
-                    );
+                    tracing::error!("request_id={} Sync Error: {}", request_id, e);
                     let err_xml = r#"<?xml version="1.0" encoding="utf-8"?><Sync xmlns="AirSync:"><Status>6</Status></Sync>"#;
                     xml_or_wbxml_response(&wbxml, wants_wbxml, err_xml, &request_id)
                 }
@@ -1828,9 +1726,7 @@ pub async fn handle(
             )
             .await
         }
-        "Settings" => {
-            handle_settings(&username, &wbxml, wants_wbxml, &request_id, &xml).await
-        }
+        "Settings" => handle_settings(&username, &wbxml, wants_wbxml, &request_id, &xml).await,
         "ItemOperations" => {
             handle_item_operations(
                 &state,
@@ -1863,8 +1759,7 @@ pub async fn handle(
                 let instance_id = extract_first_tag_text(&xml, b"InstanceId")
                     .as_deref()
                     .and_then(parse_datetime);
-                let send_response = xml.contains("<SendResponse")
-                    || xml.contains(":SendResponse");
+                let send_response = xml.contains("<SendResponse") || xml.contains(":SendResponse");
                 if let Err(e) = sync::apply_meeting_response(
                     state.clone(),
                     &username,
@@ -1883,12 +1778,7 @@ pub async fn handle(
                         e
                     );
                     let err_xml = r#"<?xml version="1.0" encoding="utf-8"?><MeetingResponse xmlns="MeetingResponse:"><Result><Status>6</Status></Result></MeetingResponse>"#;
-                    return xml_or_wbxml_response(
-                        &wbxml,
-                        wants_wbxml,
-                        err_xml,
-                        &request_id,
-                    );
+                    return xml_or_wbxml_response(&wbxml, wants_wbxml, err_xml, &request_id);
                 }
                 let instance_xml = if let Some(iid) = instance_id {
                     format!(
@@ -1931,15 +1821,8 @@ pub async fn handle(
             &request_id,
         ),
         "GetItemEstimate" => {
-            handle_get_item_estimate(
-                &state,
-                &username,
-                &req,
-                &wbxml,
-                wants_wbxml,
-                &request_id,
-            )
-            .await
+            handle_get_item_estimate(&state, &username, &req, &wbxml, wants_wbxml, &request_id)
+                .await
         }
         "SendMail" | "SmartReply" | "SmartForward" => success_status_response(
             &wbxml,
@@ -1954,11 +1837,6 @@ pub async fn handle(
             &request_id,
             "MoveItems is not supported for this calendar-only mailbox surface",
         ),
-        _ => unsupported_command_response(
-            &req.command,
-            &wbxml,
-            wants_wbxml,
-            &request_id,
-        ),
+        _ => unsupported_command_response(&req.command, &wbxml, wants_wbxml, &request_id),
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,10 @@ impl GatewayError {
         }
     }
 
-    pub fn protocol_with_source(context: impl Into<String>, source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+    pub fn protocol_with_source(
+        context: impl Into<String>,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+    ) -> Self {
         GatewayError::Protocol {
             context: context.into(),
             source: Some(source.into()),

--- a/src/ews.rs
+++ b/src/ews.rs
@@ -5,8 +5,7 @@ use crate::calendar::{
     parse_ews_recurrence, parse_ics_event, render_ics,
 };
 use crate::ews_folders::{
-    DistinguishedFolder, folder_id_for, render_folder_xml,
-    validate_folder_request,
+    DistinguishedFolder, folder_id_for, render_folder_xml, validate_folder_request,
 };
 use crate::ews_update::{apply_field_changes, parse_item_changes};
 use crate::models::AppState;
@@ -30,112 +29,234 @@ const EWS_MSG_NS: &str = "http://schemas.microsoft.com/exchange/services/2006/me
 const EWS_TYPE_NS: &str = "http://schemas.microsoft.com/exchange/services/2006/types";
 
 #[derive(Clone, Debug)]
-struct AuthContext { username: String, password: String }
+struct AuthContext {
+    username: String,
+    password: String,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ItemShape { IdOnly, Default, AllProperties }
+enum ItemShape {
+    IdOnly,
+    Default,
+    AllProperties,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum EwsAction {
-    GetFolder, FindFolder, FindItem, GetItem, GetUserAvailability, SyncFolderItems,
-    SyncFolderHierarchy, Subscribe, Unsubscribe, CreateItem, UpdateItem, DeleteItem, ResolveNames,
-    GetUserOofSettings, SetUserOofSettings,
-    GetServiceConfiguration, GetServerTimeZones,
-    GetFolderInfo, GetMailTips, FindPeople, GetConversationItems,
-    ConvertId, GetRoomLists, GetRooms, GetDelegate, GetUserPhoto,
-    MarkAsJunk, GetAppManifests, GetAppMarketplaceUrl,
-    InstallApp, UninstallApp, GetClientAccessToken,
-    GetReminders, PerformReminderAction, GetPersona,
+    GetFolder,
+    FindFolder,
+    FindItem,
+    GetItem,
+    GetUserAvailability,
+    SyncFolderItems,
+    SyncFolderHierarchy,
+    Subscribe,
+    Unsubscribe,
+    CreateItem,
+    UpdateItem,
+    DeleteItem,
+    ResolveNames,
+    GetUserOofSettings,
+    SetUserOofSettings,
+    GetServiceConfiguration,
+    GetServerTimeZones,
+    GetFolderInfo,
+    GetMailTips,
+    FindPeople,
+    GetConversationItems,
+    ConvertId,
+    GetRoomLists,
+    GetRooms,
+    GetDelegate,
+    GetUserPhoto,
+    MarkAsJunk,
+    GetAppManifests,
+    GetAppMarketplaceUrl,
+    InstallApp,
+    UninstallApp,
+    GetClientAccessToken,
+    GetReminders,
+    PerformReminderAction,
+    GetPersona,
 }
 
 fn validate_schema(action: &EwsAction, xml: &str) -> Result<(), &'static str> {
-    if !xml.contains("Envelope") || !xml.contains("Body") { return Err("Missing SOAP Envelope or Body"); }
-    if !xml.contains(EWS_MSG_NS) && !xml.contains("xmlns:m=") { return Err("Missing EWS messages namespace"); }
+    if !xml.contains("Envelope") || !xml.contains("Body") {
+        return Err("Missing SOAP Envelope or Body");
+    }
+    if !xml.contains(EWS_MSG_NS) && !xml.contains("xmlns:m=") {
+        return Err("Missing EWS messages namespace");
+    }
     match action {
         EwsAction::GetFolder => {
-            if !xml.contains("FolderShape") || !xml.contains("FolderIds") { return Err("GetFolder requires FolderShape and FolderIds"); }
+            if !xml.contains("FolderShape") || !xml.contains("FolderIds") {
+                return Err("GetFolder requires FolderShape and FolderIds");
+            }
             Ok(())
         }
         EwsAction::FindFolder => {
-            if !xml.contains("FolderShape") || !xml.contains("ParentFolderIds") { return Err("FindFolder requires FolderShape and ParentFolderIds"); }
+            if !xml.contains("FolderShape") || !xml.contains("ParentFolderIds") {
+                return Err("FindFolder requires FolderShape and ParentFolderIds");
+            }
             Ok(())
         }
         EwsAction::FindItem => {
-            if !xml.contains("ParentFolderIds") || !xml.contains("ItemShape") { return Err("FindItem requires ParentFolderIds and ItemShape"); }
-            if xml.contains("IncludeMimeContent") { return Err("FindItem does not support IncludeMimeContent"); }
+            if !xml.contains("ParentFolderIds") || !xml.contains("ItemShape") {
+                return Err("FindItem requires ParentFolderIds and ItemShape");
+            }
+            if xml.contains("IncludeMimeContent") {
+                return Err("FindItem does not support IncludeMimeContent");
+            }
             let max = extract_int(xml, b"MaxEntriesReturned", 50);
-            if max == 0 { return Err("FindItem MaxEntriesReturned must be greater than zero"); }
+            if max == 0 {
+                return Err("FindItem MaxEntriesReturned must be greater than zero");
+            }
             Ok(())
         }
         EwsAction::GetItem => {
-            if !xml.contains("ItemShape") || !xml.contains("ItemIds") { return Err("GetItem requires ItemShape and ItemIds"); }
+            if !xml.contains("ItemShape") || !xml.contains("ItemIds") {
+                return Err("GetItem requires ItemShape and ItemIds");
+            }
             Ok(())
         }
         EwsAction::GetUserAvailability => {
-            if !xml.contains("MailboxDataArray") || !xml.contains("FreeBusyViewOptions") { return Err("GetUserAvailability requires MailboxDataArray and FreeBusyViewOptions"); }
+            if !xml.contains("MailboxDataArray") || !xml.contains("FreeBusyViewOptions") {
+                return Err(
+                    "GetUserAvailability requires MailboxDataArray and FreeBusyViewOptions",
+                );
+            }
             Ok(())
         }
         EwsAction::SyncFolderItems => {
-            if !xml.contains("SyncFolderId") { return Err("SyncFolderItems requires SyncFolderId"); }
-            if !xml.contains("MaxChangesReturned") { return Err("SyncFolderItems requires MaxChangesReturned"); }
-            if xml.contains("IncludeMimeContent") { return Err("SyncFolderItems does not support IncludeMimeContent"); }
+            if !xml.contains("SyncFolderId") {
+                return Err("SyncFolderItems requires SyncFolderId");
+            }
+            if !xml.contains("MaxChangesReturned") {
+                return Err("SyncFolderItems requires MaxChangesReturned");
+            }
+            if xml.contains("IncludeMimeContent") {
+                return Err("SyncFolderItems does not support IncludeMimeContent");
+            }
             Ok(())
         }
         EwsAction::SyncFolderHierarchy => {
-            if !xml.contains("FolderShape") { return Err("SyncFolderHierarchy requires FolderShape"); }
+            if !xml.contains("FolderShape") {
+                return Err("SyncFolderHierarchy requires FolderShape");
+            }
             Ok(())
         }
         EwsAction::Subscribe => {
-            if !xml.contains("PullSubscriptionRequest") && !xml.contains("PushSubscriptionRequest") && !xml.contains("StreamingSubscriptionRequest") {
+            if !xml.contains("PullSubscriptionRequest")
+                && !xml.contains("PushSubscriptionRequest")
+                && !xml.contains("StreamingSubscriptionRequest")
+            {
                 return Err("Subscribe requires a subscription type");
             }
             Ok(())
         }
         EwsAction::Unsubscribe => {
-            if !xml.contains("SubscriptionId") { return Err("Unsubscribe requires SubscriptionId"); }
+            if !xml.contains("SubscriptionId") {
+                return Err("Unsubscribe requires SubscriptionId");
+            }
             Ok(())
         }
         EwsAction::CreateItem => {
-            if !xml.contains("SavedItemFolderId") || !xml.contains("Items") { return Err("CreateItem requires SavedItemFolderId and Items"); }
-            validate_attr_enum(xml, b"CreateItem", b"SendMeetingInvitations",
-                &["SendToNone", "SendOnlyToAll", "SendToAllAndSaveCopy"], "CreateItem SendMeetingInvitations value is unsupported")?;
+            if !xml.contains("SavedItemFolderId") || !xml.contains("Items") {
+                return Err("CreateItem requires SavedItemFolderId and Items");
+            }
+            validate_attr_enum(
+                xml,
+                b"CreateItem",
+                b"SendMeetingInvitations",
+                &["SendToNone", "SendOnlyToAll", "SendToAllAndSaveCopy"],
+                "CreateItem SendMeetingInvitations value is unsupported",
+            )?;
             Ok(())
         }
         EwsAction::UpdateItem => {
-            if !xml.contains("ItemChanges") { return Err("UpdateItem requires ItemChanges"); }
-            validate_attr_enum(xml, b"UpdateItem", b"ConflictResolution",
-                &["NeverOverwrite", "AutoResolve", "AlwaysOverwrite"], "UpdateItem ConflictResolution value is unsupported")?;
-            validate_attr_enum(xml, b"UpdateItem", b"MessageDisposition",
-                &["SaveOnly", "SendOnly", "SendAndSaveCopy"], "UpdateItem MessageDisposition value is unsupported")?;
-            validate_attr_enum(xml, b"UpdateItem", b"SendMeetingInvitationsOrCancellations",
-                &["SendToNone", "SendOnlyToAll", "SendToAllAndSaveCopy"], "UpdateItem SendMeetingInvitationsOrCancellations value is unsupported")?;
+            if !xml.contains("ItemChanges") {
+                return Err("UpdateItem requires ItemChanges");
+            }
+            validate_attr_enum(
+                xml,
+                b"UpdateItem",
+                b"ConflictResolution",
+                &["NeverOverwrite", "AutoResolve", "AlwaysOverwrite"],
+                "UpdateItem ConflictResolution value is unsupported",
+            )?;
+            validate_attr_enum(
+                xml,
+                b"UpdateItem",
+                b"MessageDisposition",
+                &["SaveOnly", "SendOnly", "SendAndSaveCopy"],
+                "UpdateItem MessageDisposition value is unsupported",
+            )?;
+            validate_attr_enum(
+                xml,
+                b"UpdateItem",
+                b"SendMeetingInvitationsOrCancellations",
+                &["SendToNone", "SendOnlyToAll", "SendToAllAndSaveCopy"],
+                "UpdateItem SendMeetingInvitationsOrCancellations value is unsupported",
+            )?;
             Ok(())
         }
         EwsAction::DeleteItem => {
-            if !xml.contains("ItemIds") { return Err("DeleteItem requires ItemIds"); }
-            validate_attr_enum(xml, b"DeleteItem", b"DeleteType",
-                &["HardDelete", "SoftDelete", "MoveToDeletedItems"], "DeleteItem DeleteType value is unsupported")?;
-            validate_attr_enum(xml, b"DeleteItem", b"SendMeetingCancellations",
-                &["SendToNone", "SendOnlyToAll", "SendToAllAndSaveCopy"], "DeleteItem SendMeetingCancellations value is unsupported")?;
+            if !xml.contains("ItemIds") {
+                return Err("DeleteItem requires ItemIds");
+            }
+            validate_attr_enum(
+                xml,
+                b"DeleteItem",
+                b"DeleteType",
+                &["HardDelete", "SoftDelete", "MoveToDeletedItems"],
+                "DeleteItem DeleteType value is unsupported",
+            )?;
+            validate_attr_enum(
+                xml,
+                b"DeleteItem",
+                b"SendMeetingCancellations",
+                &["SendToNone", "SendOnlyToAll", "SendToAllAndSaveCopy"],
+                "DeleteItem SendMeetingCancellations value is unsupported",
+            )?;
             Ok(())
         }
         EwsAction::ResolveNames => {
-            if !xml.contains("UnresolvedEntry") { return Err("ResolveNames requires UnresolvedEntry"); }
+            if !xml.contains("UnresolvedEntry") {
+                return Err("ResolveNames requires UnresolvedEntry");
+            }
             Ok(())
         }
-        EwsAction::GetUserOofSettings | EwsAction::SetUserOofSettings | EwsAction::GetServiceConfiguration |
-        EwsAction::GetServerTimeZones | EwsAction::GetFolderInfo | EwsAction::GetMailTips |
-        EwsAction::FindPeople | EwsAction::GetConversationItems |
-        EwsAction::ConvertId | EwsAction::GetRoomLists | EwsAction::GetRooms |
-        EwsAction::GetDelegate | EwsAction::GetUserPhoto |
-        EwsAction::MarkAsJunk | EwsAction::GetAppManifests | EwsAction::GetAppMarketplaceUrl |
-        EwsAction::InstallApp | EwsAction::UninstallApp | EwsAction::GetClientAccessToken |
-    EwsAction::GetReminders | EwsAction::PerformReminderAction | EwsAction::GetPersona
-        => Ok(()),
+        EwsAction::GetUserOofSettings
+        | EwsAction::SetUserOofSettings
+        | EwsAction::GetServiceConfiguration
+        | EwsAction::GetServerTimeZones
+        | EwsAction::GetFolderInfo
+        | EwsAction::GetMailTips
+        | EwsAction::FindPeople
+        | EwsAction::GetConversationItems
+        | EwsAction::ConvertId
+        | EwsAction::GetRoomLists
+        | EwsAction::GetRooms
+        | EwsAction::GetDelegate
+        | EwsAction::GetUserPhoto
+        | EwsAction::MarkAsJunk
+        | EwsAction::GetAppManifests
+        | EwsAction::GetAppMarketplaceUrl
+        | EwsAction::InstallApp
+        | EwsAction::UninstallApp
+        | EwsAction::GetClientAccessToken
+        | EwsAction::GetReminders
+        | EwsAction::PerformReminderAction
+        | EwsAction::GetPersona => Ok(()),
     }
 }
 
-fn operation_error_response(action: &EwsAction, code: &str, message: &str, status: StatusCode) -> Response {
+fn operation_error_response(
+    action: &EwsAction,
+    code: &str,
+    message: &str,
+    status: StatusCode,
+) -> Response {
     let resp_msg = match action {
         EwsAction::GetFolder => "GetFolderResponseMessage",
         EwsAction::FindFolder => "FindFolderResponseMessage",
@@ -175,7 +296,11 @@ fn operation_error_response(action: &EwsAction, code: &str, message: &str, statu
     };
     let inner = format!(
         r#"<m:{resp} ResponseClass="Error" xmlns:m="{msg_ns}" xmlns:t="{type_ns}"><m:MessageText>{}</m:MessageText><m:ResponseCode>{}</m:ResponseCode><m:DescriptiveLinkKey>0</m:DescriptiveLinkKey></m:{resp}>"#,
-        xml_escape(message), xml_escape(code), resp = resp_msg, msg_ns = EWS_MSG_NS, type_ns = EWS_TYPE_NS
+        xml_escape(message),
+        xml_escape(code),
+        resp = resp_msg,
+        msg_ns = EWS_MSG_NS,
+        type_ns = EWS_TYPE_NS
     );
     let prefix = &resp_msg[..resp_msg.len().saturating_sub("ResponseMessage".len())];
     let body = format!(
@@ -188,18 +313,35 @@ fn operation_error_response(action: &EwsAction, code: &str, message: &str, statu
   <s:Header><t:ServerVersionInfo MajorVersion="15" MinorVersion="20" MajorBuildNumber="0" MinorBuildNumber="0" Version="Exchange2016" xmlns:t="{type_ns}" /></s:Header>
   <s:Body>{body}</s:Body>
 </s:Envelope>"#,
-        type_ns = EWS_TYPE_NS, body = body
+        type_ns = EWS_TYPE_NS,
+        body = body
     );
     (status, [("Content-Type", "text/xml; charset=utf-8")], xml).into_response()
 }
 
-pub async fn handle(State(state): State<Arc<AppState>>, headers: HeaderMap, body: String) -> Response {
-    let auth = match parse_basic_auth(&headers) { Some(a) => a, None => return unauthorized() };
+pub async fn handle(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    let auth = match parse_basic_auth(&headers) {
+        Some(a) => a,
+        None => return unauthorized(),
+    };
     let Some(action) = detect_action(&body) else {
-        return soap_fault("ErrorInvalidRequest", "Could not detect EWS action from SOAP request body", StatusCode::BAD_REQUEST);
+        return soap_fault(
+            "ErrorInvalidRequest",
+            "Could not detect EWS action from SOAP request body",
+            StatusCode::BAD_REQUEST,
+        );
     };
     if let Err(e) = validate_schema(&action, &body) {
-        return operation_error_response(&action, "ErrorSchemaValidation", e, StatusCode::BAD_REQUEST);
+        return operation_error_response(
+            &action,
+            "ErrorSchemaValidation",
+            e,
+            StatusCode::BAD_REQUEST,
+        );
     }
     match action {
         EwsAction::GetFolder => handle_get_folder(&state, &auth, &body).await,
@@ -247,7 +389,10 @@ fn parse_basic_auth(headers: &HeaderMap) -> Option<AuthContext> {
     STANDARD.decode_vec(b64.as_bytes(), &mut decoded).ok()?;
     let pair = String::from_utf8(decoded).ok()?;
     let idx = pair.find(':')?;
-    Some(AuthContext { username: pair[..idx].to_string(), password: pair[idx + 1..].to_string() })
+    Some(AuthContext {
+        username: pair[..idx].to_string(),
+        password: pair[idx + 1..].to_string(),
+    })
 }
 
 fn detect_action(xml: &str) -> Option<EwsAction> {
@@ -280,21 +425,24 @@ fn detect_action(xml: &str) -> Option<EwsAction> {
                     b"GetMailTips" => EwsAction::GetMailTips,
                     b"FindPeople" => EwsAction::FindPeople,
                     b"GetConversationItems" => EwsAction::GetConversationItems,
-        b"ConvertId" => EwsAction::ConvertId,
-        b"GetRoomLists" => EwsAction::GetRoomLists,
-        b"GetRooms" => EwsAction::GetRooms,
-        b"GetDelegate" => EwsAction::GetDelegate,
-        b"GetUserPhoto" => EwsAction::GetUserPhoto,
-        b"MarkAsJunk" => EwsAction::MarkAsJunk,
-        b"GetAppManifests" => EwsAction::GetAppManifests,
-        b"GetAppMarketplaceUrl" => EwsAction::GetAppMarketplaceUrl,
-        b"InstallApp" => EwsAction::InstallApp,
-        b"UninstallApp" => EwsAction::UninstallApp,
-        b"GetClientAccessToken" => EwsAction::GetClientAccessToken,
+                    b"ConvertId" => EwsAction::ConvertId,
+                    b"GetRoomLists" => EwsAction::GetRoomLists,
+                    b"GetRooms" => EwsAction::GetRooms,
+                    b"GetDelegate" => EwsAction::GetDelegate,
+                    b"GetUserPhoto" => EwsAction::GetUserPhoto,
+                    b"MarkAsJunk" => EwsAction::MarkAsJunk,
+                    b"GetAppManifests" => EwsAction::GetAppManifests,
+                    b"GetAppMarketplaceUrl" => EwsAction::GetAppMarketplaceUrl,
+                    b"InstallApp" => EwsAction::InstallApp,
+                    b"UninstallApp" => EwsAction::UninstallApp,
+                    b"GetClientAccessToken" => EwsAction::GetClientAccessToken,
                     b"GetReminders" => EwsAction::GetReminders,
                     b"PerformReminderAction" => EwsAction::PerformReminderAction,
                     b"GetPersona" => EwsAction::GetPersona,
-                    _ => { buf.clear(); continue; }
+                    _ => {
+                        buf.clear();
+                        continue;
+                    }
                 });
             }
             Ok(Event::Eof) | Err(_) => return None,
@@ -317,7 +465,11 @@ fn extract_tag_texts(xml: &str, tag: &[u8]) -> Vec<String> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.name().local_name().as_ref() == tag => inside = true,
-            Ok(Event::Text(t)) if inside => { if let Ok(value) = t.decode() { values.push(value.into_owned()); } }
+            Ok(Event::Text(t)) if inside => {
+                if let Ok(value) = t.decode() {
+                    values.push(value.into_owned());
+                }
+            }
             Ok(Event::End(e)) if e.name().local_name().as_ref() == tag => inside = false,
             Ok(Event::Eof) | Err(_) => return values,
             _ => {}
@@ -336,7 +488,9 @@ fn extract_first_attr(xml: &str, tag: &[u8], attr: &[u8]) -> Option<String> {
                 for a in e.attributes().flatten() {
                     if a.key.local_name().as_ref() == attr
                         && let Ok(v) = a.decode_and_unescape_value(reader.decoder())
-                    { return Some(v.into_owned()); }
+                    {
+                        return Some(v.into_owned());
+                    }
                 }
             }
             Ok(Event::Eof) | Err(_) => return None,
@@ -347,59 +501,131 @@ fn extract_first_attr(xml: &str, tag: &[u8], attr: &[u8]) -> Option<String> {
 }
 
 fn extract_int(xml: &str, tag: &[u8], default: usize) -> usize {
-    extract_first_tag_text(xml, tag).and_then(|v| v.parse::<usize>().ok()).unwrap_or(default)
+    extract_first_tag_text(xml, tag)
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
 }
 
-fn validate_attr_enum(xml: &str, tag: &[u8], attr: &[u8], allowed: &[&str], err: &'static str) -> Result<(), &'static str> {
+fn validate_attr_enum(
+    xml: &str,
+    tag: &[u8],
+    attr: &[u8],
+    allowed: &[&str],
+    err: &'static str,
+) -> Result<(), &'static str> {
     if let Some(value) = extract_first_attr(xml, tag, attr)
         && !allowed.iter().any(|c| c.eq_ignore_ascii_case(&value))
-    { return Err(err); }
+    {
+        return Err(err);
+    }
     Ok(())
 }
 
-fn owner_from_username(username: &str) -> &str { username }
-fn folder_id_for_owner(owner: &str) -> String { folder_id_for(owner, DistinguishedFolder::Calendar) }
+fn owner_from_username(username: &str) -> &str {
+    username
+}
+fn folder_id_for_owner(owner: &str) -> String {
+    folder_id_for(owner, DistinguishedFolder::Calendar)
+}
 
 fn changekey_for_item(item: &EwsItemRow) -> String {
     let mut h = Sha256::new();
     h.update(item.server_id.as_bytes());
-    if let Some(e) = &item.etag { h.update(e.as_bytes()); }
-    if let Some(u) = &item.updated_at { h.update(u.as_bytes()); }
+    if let Some(e) = &item.etag {
+        h.update(e.as_bytes());
+    }
+    if let Some(u) = &item.updated_at {
+        h.update(u.as_bytes());
+    }
     let digest = h.finalize();
     digest[..12].iter().map(|b| format!("{:02x}", b)).collect()
 }
 
 fn xml_escape(v: &str) -> String {
-    v.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&quot;").replace('\'', "&apos;")
+    v.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
 }
 
-fn busy_status_to_ews(value: u8) -> &'static str { match value { 0 => "Free", 1 => "Tentative", 3 => "OOF", _ => "Busy" } }
-fn sensitivity_to_ews(value: u8) -> &'static str { match value { 1 => "Personal", 2 => "Private", 3 => "Confidential", _ => "Normal" } }
+fn busy_status_to_ews(value: u8) -> &'static str {
+    match value {
+        0 => "Free",
+        1 => "Tentative",
+        3 => "OOF",
+        _ => "Busy",
+    }
+}
+fn sensitivity_to_ews(value: u8) -> &'static str {
+    match value {
+        1 => "Personal",
+        2 => "Private",
+        3 => "Confidential",
+        _ => "Normal",
+    }
+}
 
 fn derived_meeting_status(item: &crate::calendar::CalendarItem) -> u8 {
-    if let Some(v) = item.meeting_status { return v; }
+    if let Some(v) = item.meeting_status {
+        return v;
+    }
     let is_meeting = !item.attendees.is_empty();
-    let organizer = item.organizer_email.as_deref().map(|v| !v.is_empty()).unwrap_or(false);
-    if !is_meeting { 0 } else if organizer { 1 } else { 3 }
+    let organizer = item
+        .organizer_email
+        .as_deref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if !is_meeting {
+        0
+    } else if organizer {
+        1
+    } else {
+        3
+    }
 }
 
 fn derived_response_type(item: &crate::calendar::CalendarItem) -> Option<&'static str> {
     if let Some(v) = item.response_type {
-        return Some(match v { 1 => "Organizer", 2 => "Tentative", 3 => "Accept", 4 => "Decline", 5 => "NoResponseReceived", _ => "Unknown" });
+        return Some(match v {
+            1 => "Organizer",
+            2 => "Tentative",
+            3 => "Accept",
+            4 => "Decline",
+            5 => "NoResponseReceived",
+            _ => "Unknown",
+        });
     }
-    if derived_meeting_status(item) == 1 { return Some("Organizer"); }
+    if derived_meeting_status(item) == 1 {
+        return Some("Organizer");
+    }
     item.attendees.iter().find_map(|a| match a.attendee_status {
-        Some(2) => Some("Tentative"), Some(3) => Some("Accept"), Some(4) => Some("Decline"), Some(5) => Some("NoResponseReceived"), _ => None,
+        Some(2) => Some("Tentative"),
+        Some(3) => Some("Accept"),
+        Some(4) => Some("Decline"),
+        Some(5) => Some("NoResponseReceived"),
+        _ => None,
     })
 }
 
-fn extract_requested_change_key(xml: &str) -> Option<String> { extract_first_attr(xml, b"ItemId", b"ChangeKey") }
+fn extract_requested_change_key(xml: &str) -> Option<String> {
+    extract_first_attr(xml, b"ItemId", b"ChangeKey")
+}
 
-fn validate_item_change_key(action: &EwsAction, body: &str, item: &EwsItemRow) -> Result<(), Response> {
+fn validate_item_change_key(
+    action: &EwsAction,
+    body: &str,
+    item: &EwsItemRow,
+) -> Result<(), Response> {
     if let Some(requested) = extract_requested_change_key(body) {
         let expected = changekey_for_item(item);
         if requested != expected {
-            return Err(operation_error_response(action, "ErrorIrresolvableConflict", "Item ChangeKey does not match the current stored version", StatusCode::OK));
+            return Err(operation_error_response(
+                action,
+                "ErrorIrresolvableConflict",
+                "Item ChangeKey does not match the current stored version",
+                StatusCode::OK,
+            ));
         }
     }
     Ok(())
@@ -409,27 +635,60 @@ fn render_ews_attendees(item: &crate::calendar::CalendarItem) -> String {
     let mut required = String::new();
     let mut optional = String::new();
     for attendee in &item.attendees {
-        let response = match attendee.attendee_status.unwrap_or(5) { 3 => "Accept", 2 => "Tentative", 4 => "Decline", _ => "Unknown" };
+        let response = match attendee.attendee_status.unwrap_or(5) {
+            3 => "Accept",
+            2 => "Tentative",
+            4 => "Decline",
+            _ => "Unknown",
+        };
         let xml = format!(
             r#"<t:Attendee><t:Mailbox><t:Name>{}</t:Name><t:EmailAddress>{}</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox><t:ResponseType>{}</t:ResponseType></t:Attendee>"#,
-            xml_escape(attendee.name.as_deref().unwrap_or(&attendee.email)), xml_escape(&attendee.email), response
+            xml_escape(attendee.name.as_deref().unwrap_or(&attendee.email)),
+            xml_escape(&attendee.email),
+            response
         );
-        if attendee.attendee_type == Some(2) { optional.push_str(&xml); } else { required.push_str(&xml); }
+        if attendee.attendee_type == Some(2) {
+            optional.push_str(&xml);
+        } else {
+            required.push_str(&xml);
+        }
     }
     let mut out = String::new();
-    if !required.is_empty() { out.push_str(&format!("<t:RequiredAttendees>{}</t:RequiredAttendees>", required)); }
-    if !optional.is_empty() { out.push_str(&format!("<t:OptionalAttendees>{}</t:OptionalAttendees>", optional)); }
+    if !required.is_empty() {
+        out.push_str(&format!(
+            "<t:RequiredAttendees>{}</t:RequiredAttendees>",
+            required
+        ));
+    }
+    if !optional.is_empty() {
+        out.push_str(&format!(
+            "<t:OptionalAttendees>{}</t:OptionalAttendees>",
+            optional
+        ));
+    }
     out
 }
 
 fn render_ews_categories(item: &crate::calendar::CalendarItem) -> String {
-    if item.categories.is_empty() { return String::new(); }
-    format!("<t:Categories>{}</t:Categories>",
-        item.categories.iter().map(|v| format!("<t:String>{}</t:String>", xml_escape(v))).collect::<Vec<_>>().join(""))
+    if item.categories.is_empty() {
+        return String::new();
+    }
+    format!(
+        "<t:Categories>{}</t:Categories>",
+        item.categories
+            .iter()
+            .map(|v| format!("<t:String>{}</t:String>", xml_escape(v)))
+            .collect::<Vec<_>>()
+            .join("")
+    )
 }
 
 fn ews_calendar_item_type(item: &crate::calendar::CalendarItem) -> &'static str {
-    if item.rrule.is_some() { "RecurringMaster" } else { "Single" }
+    if item.rrule.is_some() {
+        "RecurringMaster"
+    } else {
+        "Single"
+    }
 }
 
 fn ews_my_response_type(item: &crate::calendar::CalendarItem) -> &'static str {
@@ -440,33 +699,71 @@ fn ews_calendar_event_details_xml(item: &crate::calendar::CalendarItem) -> Strin
     let is_private = item.sensitivity.map(|v| v >= 2).unwrap_or(false);
     format!(
         "<t:CalendarEventDetails><t:Subject>{}</t:Subject><t:Location>{}</t:Location><t:IsMeeting>{}</t:IsMeeting><t:IsRecurring>{}</t:IsRecurring><t:IsException>false</t:IsException><t:IsReminderSet>{}</t:IsReminderSet><t:IsPrivate>{}</t:IsPrivate></t:CalendarEventDetails>",
-        xml_escape(&item.subject), xml_escape(&item.location),
-        if item.attendees.is_empty() { "false" } else { "true" },
-        if item.rrule.is_some() { "true" } else { "false" },
-        if item.reminder.is_some() { "true" } else { "false" },
+        xml_escape(&item.subject),
+        xml_escape(&item.location),
+        if item.attendees.is_empty() {
+            "false"
+        } else {
+            "true"
+        },
+        if item.rrule.is_some() {
+            "true"
+        } else {
+            "false"
+        },
+        if item.reminder.is_some() {
+            "true"
+        } else {
+            "false"
+        },
         if is_private { "true" } else { "false" }
     )
 }
 
 fn ews_deleted_occurrences_xml(item: &crate::calendar::CalendarItem) -> String {
-    let mut starts = item.exceptions.iter().filter(|e| e.deleted).map(|e| e.exception_start).collect::<Vec<_>>();
+    let mut starts = item
+        .exceptions
+        .iter()
+        .filter(|e| e.deleted)
+        .map(|e| e.exception_start)
+        .collect::<Vec<_>>();
     starts.extend(item.exdates.iter().copied());
     starts.sort();
     starts.dedup();
-    if starts.is_empty() { return String::new(); }
-    format!("<t:DeletedOccurrences>{}</t:DeletedOccurrences>",
-        starts.iter().map(|s| format!("<t:DeletedOccurrence><t:Start>{}</t:Start></t:DeletedOccurrence>", s.to_rfc3339())).collect::<String>())
+    if starts.is_empty() {
+        return String::new();
+    }
+    format!(
+        "<t:DeletedOccurrences>{}</t:DeletedOccurrences>",
+        starts
+            .iter()
+            .map(|s| format!(
+                "<t:DeletedOccurrence><t:Start>{}</t:Start></t:DeletedOccurrence>",
+                s.to_rfc3339()
+            ))
+            .collect::<String>()
+    )
 }
 
 fn ews_response_objects_xml(item: &crate::calendar::CalendarItem) -> String {
     let is_meeting = !item.attendees.is_empty();
-    let is_organizer = item.organizer_email.as_deref().map(|v| !v.is_empty()).unwrap_or(false);
+    let is_organizer = item
+        .organizer_email
+        .as_deref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
     let response_requested = item.response_requested.unwrap_or(is_meeting);
-    if !is_meeting || is_organizer || !response_requested { return String::new(); }
+    if !is_meeting || is_organizer || !response_requested {
+        return String::new();
+    }
     "<t:ResponseObjects><t:AcceptItem /><t:TentativelyAcceptItem /><t:DeclineItem /></t:ResponseObjects>".to_string()
 }
 
-fn ews_modified_occurrences_xml(item_id: &str, change_key: &str, item: &crate::calendar::CalendarItem) -> String {
+fn ews_modified_occurrences_xml(
+    item_id: &str,
+    change_key: &str,
+    item: &crate::calendar::CalendarItem,
+) -> String {
     let modified = item.exceptions.iter().filter(|e| !e.deleted).map(|e| {
         let start = e.start.unwrap_or(e.exception_start);
         let end = e.end.unwrap_or_else(|| start + chrono::Duration::minutes(30));
@@ -477,34 +774,75 @@ fn ews_modified_occurrences_xml(item_id: &str, change_key: &str, item: &crate::c
             start.to_rfc3339(), end.to_rfc3339(), e.exception_start.to_rfc3339(), xml_escape(subject)
         )
     }).collect::<String>();
-    if modified.is_empty() { String::new() } else { format!("<t:ModifiedOccurrences>{}</t:ModifiedOccurrences>", modified) }
+    if modified.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "<t:ModifiedOccurrences>{}</t:ModifiedOccurrences>",
+            modified
+        )
+    }
 }
 
 fn ews_month_name(month: &str) -> &'static str {
     match month {
-        "1" => "January", "2" => "February", "3" => "March", "4" => "April",
-        "5" => "May", "6" => "June", "7" => "July", "8" => "August",
-        "9" => "September", "10" => "October", "11" => "November", "12" => "December",
+        "1" => "January",
+        "2" => "February",
+        "3" => "March",
+        "4" => "April",
+        "5" => "May",
+        "6" => "June",
+        "7" => "July",
+        "8" => "August",
+        "9" => "September",
+        "10" => "October",
+        "11" => "November",
+        "12" => "December",
         _ => "January",
     }
 }
 
 fn ews_days_of_week(byday: &str) -> String {
-    byday.replace("MO", "Monday").replace("TU", "Tuesday").replace("WE", "Wednesday")
-        .replace("TH", "Thursday").replace("FR", "Friday").replace("SA", "Saturday")
-        .replace("SU", "Sunday").replace(',', " ")
+    byday
+        .replace("MO", "Monday")
+        .replace("TU", "Tuesday")
+        .replace("WE", "Wednesday")
+        .replace("TH", "Thursday")
+        .replace("FR", "Friday")
+        .replace("SA", "Saturday")
+        .replace("SU", "Sunday")
+        .replace(',', " ")
 }
 
-fn ews_day_of_week_index(ord: i32) -> &'static str { match ord { 1 => "First", 2 => "Second", 3 => "Third", 4 => "Fourth", -1 => "Last", _ => "First" } }
+fn ews_day_of_week_index(ord: i32) -> &'static str {
+    match ord {
+        1 => "First",
+        2 => "Second",
+        3 => "Third",
+        4 => "Fourth",
+        -1 => "Last",
+        _ => "First",
+    }
+}
 
 fn parse_rrule_byday(value: &str) -> Option<(i32, String)> {
     let mut ordinal_end = 0usize;
     for (idx, ch) in value.char_indices() {
-        if ch == '-' || ch.is_ascii_digit() { ordinal_end = idx + ch.len_utf8(); } else { break; }
+        if ch == '-' || ch.is_ascii_digit() {
+            ordinal_end = idx + ch.len_utf8();
+        } else {
+            break;
+        }
     }
-    let ordinal = if ordinal_end == 0 { 0 } else { value[..ordinal_end].parse::<i32>().ok()? };
+    let ordinal = if ordinal_end == 0 {
+        0
+    } else {
+        value[..ordinal_end].parse::<i32>().ok()?
+    };
     let code = value[ordinal_end..].to_string();
-    if code.is_empty() { return None; }
+    if code.is_empty() {
+        return None;
+    }
     Some((ordinal, code))
 }
 
@@ -531,54 +869,104 @@ fn render_ews_recurrence_xml(rrule: &str, start: chrono::DateTime<chrono::Utc>) 
         }
     }
     let pattern = match freq {
-        "DAILY" => format!("<t:DailyRecurrence><t:Interval>{}</t:Interval></t:DailyRecurrence>", interval),
-        "WEEKLY" => format!("<t:WeeklyRecurrence><t:Interval>{}</t:Interval><t:DaysOfWeek>{}</t:DaysOfWeek></t:WeeklyRecurrence>",
-            interval, ews_days_of_week(&byday.unwrap_or_default())),
+        "DAILY" => format!(
+            "<t:DailyRecurrence><t:Interval>{}</t:Interval></t:DailyRecurrence>",
+            interval
+        ),
+        "WEEKLY" => format!(
+            "<t:WeeklyRecurrence><t:Interval>{}</t:Interval><t:DaysOfWeek>{}</t:DaysOfWeek></t:WeeklyRecurrence>",
+            interval,
+            ews_days_of_week(&byday.unwrap_or_default())
+        ),
         "MONTHLY" => {
             if let Some(byday) = byday.as_deref().and_then(parse_rrule_byday) {
-                format!("<t:RelativeMonthlyRecurrence><t:Interval>{}</t:Interval><t:DaysOfWeek>{}</t:DaysOfWeek><t:DayOfWeekIndex>{}</t:DayOfWeekIndex></t:RelativeMonthlyRecurrence>",
-                    interval, ews_days_of_week(&byday.1), ews_day_of_week_index(if byday.0 == 0 { 1 } else { byday.0 }))
+                format!(
+                    "<t:RelativeMonthlyRecurrence><t:Interval>{}</t:Interval><t:DaysOfWeek>{}</t:DaysOfWeek><t:DayOfWeekIndex>{}</t:DayOfWeekIndex></t:RelativeMonthlyRecurrence>",
+                    interval,
+                    ews_days_of_week(&byday.1),
+                    ews_day_of_week_index(if byday.0 == 0 { 1 } else { byday.0 })
+                )
             } else {
-                format!("<t:AbsoluteMonthlyRecurrence><t:Interval>{}</t:Interval><t:DayOfMonth>{}</t:DayOfMonth></t:AbsoluteMonthlyRecurrence>",
-                    interval, bymonthday.unwrap_or_else(|| start.day().to_string()))
+                format!(
+                    "<t:AbsoluteMonthlyRecurrence><t:Interval>{}</t:Interval><t:DayOfMonth>{}</t:DayOfMonth></t:AbsoluteMonthlyRecurrence>",
+                    interval,
+                    bymonthday.unwrap_or_else(|| start.day().to_string())
+                )
             }
         }
         "YEARLY" => {
             let month = bymonth.unwrap_or_else(|| start.month().to_string());
             if let Some(byday) = byday.as_deref().and_then(parse_rrule_byday) {
-                format!("<t:RelativeYearlyRecurrence><t:DaysOfWeek>{}</t:DaysOfWeek><t:DayOfWeekIndex>{}</t:DayOfWeekIndex><t:Month>{}</t:Month></t:RelativeYearlyRecurrence>",
-                    ews_days_of_week(&byday.1), ews_day_of_week_index(if byday.0 == 0 { 1 } else { byday.0 }), ews_month_name(&month))
+                format!(
+                    "<t:RelativeYearlyRecurrence><t:DaysOfWeek>{}</t:DaysOfWeek><t:DayOfWeekIndex>{}</t:DayOfWeekIndex><t:Month>{}</t:Month></t:RelativeYearlyRecurrence>",
+                    ews_days_of_week(&byday.1),
+                    ews_day_of_week_index(if byday.0 == 0 { 1 } else { byday.0 }),
+                    ews_month_name(&month)
+                )
             } else {
-                format!("<t:AbsoluteYearlyRecurrence><t:Month>{}</t:Month><t:DayOfMonth>{}</t:DayOfMonth></t:AbsoluteYearlyRecurrence>",
-                    ews_month_name(&month), bymonthday.unwrap_or_else(|| start.day().to_string()))
+                format!(
+                    "<t:AbsoluteYearlyRecurrence><t:Month>{}</t:Month><t:DayOfMonth>{}</t:DayOfMonth></t:AbsoluteYearlyRecurrence>",
+                    ews_month_name(&month),
+                    bymonthday.unwrap_or_else(|| start.day().to_string())
+                )
             }
         }
         _ => return String::new(),
     };
     let range = if let Some(count) = count {
-        format!("<t:NumberedRecurrence><t:StartDate>{}</t:StartDate><t:NumberOfOccurrences>{}</t:NumberOfOccurrences></t:NumberedRecurrence>", start.format("%Y-%m-%d"), count)
+        format!(
+            "<t:NumberedRecurrence><t:StartDate>{}</t:StartDate><t:NumberOfOccurrences>{}</t:NumberOfOccurrences></t:NumberedRecurrence>",
+            start.format("%Y-%m-%d"),
+            count
+        )
     } else if let Some(until) = until {
-        let end_date = crate::calendar::parse_datetime(&until).map(|v| v.format("%Y-%m-%d").to_string()).unwrap_or(until);
-        format!("<t:EndDateRecurrence><t:StartDate>{}</t:StartDate><t:EndDate>{}</t:EndDate></t:EndDateRecurrence>", start.format("%Y-%m-%d"), end_date)
+        let end_date = crate::calendar::parse_datetime(&until)
+            .map(|v| v.format("%Y-%m-%d").to_string())
+            .unwrap_or(until);
+        format!(
+            "<t:EndDateRecurrence><t:StartDate>{}</t:StartDate><t:EndDate>{}</t:EndDate></t:EndDateRecurrence>",
+            start.format("%Y-%m-%d"),
+            end_date
+        )
     } else {
-        format!("<t:NoEndRecurrence><t:StartDate>{}</t:StartDate></t:NoEndRecurrence>", start.format("%Y-%m-%d"))
+        format!(
+            "<t:NoEndRecurrence><t:StartDate>{}</t:StartDate></t:NoEndRecurrence>",
+            start.format("%Y-%m-%d")
+        )
     };
     format!("<t:Recurrence>{}{}</t:Recurrence>", pattern, range)
 }
 
-fn render_ews_calendar_item_xml_with_shape(item_id: &str, change_key: &str, item: &crate::calendar::CalendarItem, shape: ItemShape) -> String {
+fn render_ews_calendar_item_xml_with_shape(
+    item_id: &str,
+    change_key: &str,
+    item: &crate::calendar::CalendarItem,
+    shape: ItemShape,
+) -> String {
     let created = item.dtstamp.unwrap_or_else(chrono::Utc::now);
     let duration = item.end - item.start;
     let duration_minutes = duration.num_minutes().max(0);
     let hours = duration_minutes / 60;
     let minutes = duration_minutes % 60;
     let is_meeting = !item.attendees.is_empty();
-    let is_organizer = item.organizer_email.as_deref().map(|v| !v.is_empty()).unwrap_or(false);
-    let is_cancelled = item.meeting_status.map(|s| (s & 0x04) != 0).unwrap_or(false);
+    let is_organizer = item
+        .organizer_email
+        .as_deref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let is_cancelled = item
+        .meeting_status
+        .map(|s| (s & 0x04) != 0)
+        .unwrap_or(false);
     let mut xml = format!(
         r#"<t:CalendarItem><t:ItemId Id="{}" ChangeKey="{}" /><t:Subject>{}</t:Subject><t:UID>{}</t:UID><t:Start>{}</t:Start><t:End>{}</t:End><t:IsAllDayEvent>{}</t:IsAllDayEvent>"#,
-        xml_escape(item_id), xml_escape(change_key), xml_escape(&item.subject), xml_escape(&item.uid),
-        item.start.to_rfc3339(), item.end.to_rfc3339(), if item.all_day { "true" } else { "false" }
+        xml_escape(item_id),
+        xml_escape(change_key),
+        xml_escape(&item.subject),
+        xml_escape(&item.uid),
+        item.start.to_rfc3339(),
+        item.end.to_rfc3339(),
+        if item.all_day { "true" } else { "false" }
     );
     if shape == ItemShape::IdOnly {
         xml.push_str("<t:IsDraft>false</t:IsDraft>");
@@ -586,17 +974,60 @@ fn render_ews_calendar_item_xml_with_shape(item_id: &str, change_key: &str, item
         xml.push_str("</t:CalendarItem>");
         return xml;
     }
-    if !item.location.is_empty() { xml.push_str(&format!("<t:Location>{}</t:Location>", xml_escape(&item.location))); }
-    if !item.description.is_empty() {
-        xml.push_str(&format!(r#"<t:Body BodyType="Text">{}</t:Body>"#, xml_escape(&item.description)));
-        xml.push_str(&format!("<t:TextBody>{}</t:TextBody>", xml_escape(&item.description)));
+    if !item.location.is_empty() {
+        xml.push_str(&format!(
+            "<t:Location>{}</t:Location>",
+            xml_escape(&item.location)
+        ));
     }
-    if let Some(v) = item.reminder { xml.push_str(&format!("<t:ReminderMinutesBeforeStart>{}</t:ReminderMinutesBeforeStart>", v)); }
-    xml.push_str(&format!("<t:ReminderIsSet>{}</t:ReminderIsSet>", if item.reminder.is_some() { "true" } else { "false" }));
-    if let Some(v) = item.busy_status { xml.push_str(&format!("<t:LegacyFreeBusyStatus>{}</t:LegacyFreeBusyStatus>", busy_status_to_ews(v))); }
-    if let Some(v) = item.sensitivity { xml.push_str(&format!("<t:Sensitivity>{}</t:Sensitivity>", sensitivity_to_ews(v))); }
-    if let Some(v) = item.response_requested { xml.push_str(&format!("<t:ResponseRequested>{}</t:ResponseRequested>", if v { "true" } else { "false" })); }
-    if let Some(v) = item.disallow_new_time_proposal { xml.push_str(&format!("<t:DisallowNewTimeProposal>{}</t:DisallowNewTimeProposal>", if v { "true" } else { "false" })); }
+    if !item.description.is_empty() {
+        xml.push_str(&format!(
+            r#"<t:Body BodyType="Text">{}</t:Body>"#,
+            xml_escape(&item.description)
+        ));
+        xml.push_str(&format!(
+            "<t:TextBody>{}</t:TextBody>",
+            xml_escape(&item.description)
+        ));
+    }
+    if let Some(v) = item.reminder {
+        xml.push_str(&format!(
+            "<t:ReminderMinutesBeforeStart>{}</t:ReminderMinutesBeforeStart>",
+            v
+        ));
+    }
+    xml.push_str(&format!(
+        "<t:ReminderIsSet>{}</t:ReminderIsSet>",
+        if item.reminder.is_some() {
+            "true"
+        } else {
+            "false"
+        }
+    ));
+    if let Some(v) = item.busy_status {
+        xml.push_str(&format!(
+            "<t:LegacyFreeBusyStatus>{}</t:LegacyFreeBusyStatus>",
+            busy_status_to_ews(v)
+        ));
+    }
+    if let Some(v) = item.sensitivity {
+        xml.push_str(&format!(
+            "<t:Sensitivity>{}</t:Sensitivity>",
+            sensitivity_to_ews(v)
+        ));
+    }
+    if let Some(v) = item.response_requested {
+        xml.push_str(&format!(
+            "<t:ResponseRequested>{}</t:ResponseRequested>",
+            if v { "true" } else { "false" }
+        ));
+    }
+    if let Some(v) = item.disallow_new_time_proposal {
+        xml.push_str(&format!(
+            "<t:DisallowNewTimeProposal>{}</t:DisallowNewTimeProposal>",
+            if v { "true" } else { "false" }
+        ));
+    }
     if let Some(v) = &item.organizer_email {
         xml.push_str(&format!(
             r#"<t:Organizer><t:Mailbox><t:Name>{}</t:Name><t:EmailAddress>{}</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer>"#,
@@ -607,37 +1038,102 @@ fn render_ews_calendar_item_xml_with_shape(item_id: &str, change_key: &str, item
         "<t:DateTimeCreated>{}</t:DateTimeCreated><t:DateTimeReceived>{}</t:DateTimeReceived><t:DateTimeSent>{}</t:DateTimeSent><t:DateTimeStamp>{}</t:DateTimeStamp>",
         created.to_rfc3339(), created.to_rfc3339(), created.to_rfc3339(), created.to_rfc3339()
     ));
-    xml.push_str(&format!("<t:Duration>PT{}H{}M</t:Duration>", hours, minutes));
-    xml.push_str(&format!("<t:CalendarItemType>{}</t:CalendarItemType>", ews_calendar_item_type(item)));
-    xml.push_str(&format!("<t:MyResponseType>{}</t:MyResponseType>", ews_my_response_type(item)));
+    xml.push_str(&format!(
+        "<t:Duration>PT{}H{}M</t:Duration>",
+        hours, minutes
+    ));
+    xml.push_str(&format!(
+        "<t:CalendarItemType>{}</t:CalendarItemType>",
+        ews_calendar_item_type(item)
+    ));
+    xml.push_str(&format!(
+        "<t:MyResponseType>{}</t:MyResponseType>",
+        ews_my_response_type(item)
+    ));
     xml.push_str(&format!(
         "<t:IsMeeting>{}</t:IsMeeting><t:IsOrganizer>{}</t:IsOrganizer><t:IsRecurring>{}</t:IsRecurring><t:IsCancelled>{}</t:IsCancelled><t:HasAttachments>false</t:HasAttachments>",
         if is_meeting { "true" } else { "false" }, if is_organizer { "true" } else { "false" },
         if item.rrule.is_some() { "true" } else { "false" }, if is_cancelled { "true" } else { "false" }
     ));
-    xml.push_str(&format!("<t:MeetingRequestWasSent>{}</t:MeetingRequestWasSent>", if is_meeting { "true" } else { "false" }));
-    xml.push_str(&format!("<t:AllowNewTimeProposal>{}</t:AllowNewTimeProposal>", if item.disallow_new_time_proposal.unwrap_or(false) { "false" } else { "true" }));
-    xml.push_str(&format!("<t:MeetingStatus>{}</t:MeetingStatus>", derived_meeting_status(item)));
-    if let Some(v) = derived_response_type(item) { xml.push_str(&format!("<t:ResponseType>{}</t:ResponseType>", v)); }
-    if let Some(v) = item.appointment_reply_time { xml.push_str(&format!("<t:AppointmentReplyTime>{}</t:AppointmentReplyTime>", v.to_rfc3339())); }
+    xml.push_str(&format!(
+        "<t:MeetingRequestWasSent>{}</t:MeetingRequestWasSent>",
+        if is_meeting { "true" } else { "false" }
+    ));
+    xml.push_str(&format!(
+        "<t:AllowNewTimeProposal>{}</t:AllowNewTimeProposal>",
+        if item.disallow_new_time_proposal.unwrap_or(false) {
+            "false"
+        } else {
+            "true"
+        }
+    ));
+    xml.push_str(&format!(
+        "<t:MeetingStatus>{}</t:MeetingStatus>",
+        derived_meeting_status(item)
+    ));
+    if let Some(v) = derived_response_type(item) {
+        xml.push_str(&format!("<t:ResponseType>{}</t:ResponseType>", v));
+    }
+    if let Some(v) = item.appointment_reply_time {
+        xml.push_str(&format!(
+            "<t:AppointmentReplyTime>{}</t:AppointmentReplyTime>",
+            v.to_rfc3339()
+        ));
+    }
     if let Some(v) = &item.timezone {
-        xml.push_str(&format!("<t:StartTimeZone>{}</t:StartTimeZone>", xml_escape(v)));
+        xml.push_str(&format!(
+            "<t:StartTimeZone>{}</t:StartTimeZone>",
+            xml_escape(v)
+        ));
         xml.push_str(&format!("<t:EndTimeZone>{}</t:EndTimeZone>", xml_escape(v)));
     }
-    if let Some(v) = &item.timezone_blob { xml.push_str(&format!("<t:MeetingTimeZone>{}</t:MeetingTimeZone>", xml_escape(v))); }
-    if let Some(v) = &item.online_meeting_conf_link { xml.push_str(&format!("<t:OnlineMeetingConfLink>{}</t:OnlineMeetingConfLink>", xml_escape(v))); }
-    if let Some(v) = &item.online_meeting_external_link { xml.push_str(&format!("<t:OnlineMeetingExternalLink>{}</t:OnlineMeetingExternalLink>", xml_escape(v))); }
-    if let Some(v) = &item.client_uid { xml.push_str(&format!("<t:ClientUid>{}</t:ClientUid>", xml_escape(v))); }
+    if let Some(v) = &item.timezone_blob {
+        xml.push_str(&format!(
+            "<t:MeetingTimeZone>{}</t:MeetingTimeZone>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = &item.online_meeting_conf_link {
+        xml.push_str(&format!(
+            "<t:OnlineMeetingConfLink>{}</t:OnlineMeetingConfLink>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = &item.online_meeting_external_link {
+        xml.push_str(&format!(
+            "<t:OnlineMeetingExternalLink>{}</t:OnlineMeetingExternalLink>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = &item.client_uid {
+        xml.push_str(&format!("<t:ClientUid>{}</t:ClientUid>", xml_escape(v)));
+    }
     xml.push_str("<t:AdjacentMeetingCount>0</t:AdjacentMeetingCount><t:ConflictingMeetingCount>0</t:ConflictingMeetingCount>");
     if shape == ItemShape::Default {
         xml.push_str(&ews_response_objects_xml(item));
         xml.push_str("<t:IsDraft>false</t:IsDraft>");
         xml.push_str("<t:DisplayTo>");
-        xml.push_str(&xml_escape(&item.attendees.iter().map(|a| a.name.as_deref().unwrap_or(&a.email)).collect::<Vec<_>>().join("; ")));
+        xml.push_str(&xml_escape(
+            &item
+                .attendees
+                .iter()
+                .map(|a| a.name.as_deref().unwrap_or(&a.email))
+                .collect::<Vec<_>>()
+                .join("; "),
+        ));
         xml.push_str("</t:DisplayTo>");
-        xml.push_str(&format!("<t:LastModifiedName>{}</t:LastModifiedName>", xml_escape(item.organizer_name.as_deref().unwrap_or("Unknown"))));
-        xml.push_str(&format!("<t:LastModifiedTime>{}</t:LastModifiedTime>", item.dtstamp.unwrap_or_else(chrono::Utc::now).to_rfc3339()));
-        xml.push_str(&format!("<t:Size>{}</t:Size>", item.subject.len() + item.description.len() + item.location.len() + 512));
+        xml.push_str(&format!(
+            "<t:LastModifiedName>{}</t:LastModifiedName>",
+            xml_escape(item.organizer_name.as_deref().unwrap_or("Unknown"))
+        ));
+        xml.push_str(&format!(
+            "<t:LastModifiedTime>{}</t:LastModifiedTime>",
+            item.dtstamp.unwrap_or_else(chrono::Utc::now).to_rfc3339()
+        ));
+        xml.push_str(&format!(
+            "<t:Size>{}</t:Size>",
+            item.subject.len() + item.description.len() + item.location.len() + 512
+        ));
         xml.push_str("<t:EffectiveRights><t:CreateAssociated>false</t:CreateAssociated><t:CreateContents>true</t:CreateContents><t:CreateHierarchy>false</t:CreateHierarchy><t:Delete>true</t:Delete><t:Modify>true</t:Modify><t:Read>true</t:Read></t:EffectiveRights>");
         xml.push_str("</t:CalendarItem>");
         return xml;
@@ -646,30 +1142,57 @@ fn render_ews_calendar_item_xml_with_shape(item_id: &str, change_key: &str, item
     xml.push_str(&render_ews_attendees(item));
     xml.push_str(&ews_deleted_occurrences_xml(item));
     xml.push_str(&ews_modified_occurrences_xml(item_id, change_key, item));
-    if let Some(rrule) = &item.rrule { xml.push_str(&render_ews_recurrence_xml(rrule, item.start)); }
+    if let Some(rrule) = &item.rrule {
+        xml.push_str(&render_ews_recurrence_xml(rrule, item.start));
+    }
     xml.push_str(&ews_response_objects_xml(item));
     xml.push_str("<t:IsDraft>false</t:IsDraft>");
     xml.push_str("<t:DisplayTo>");
-    xml.push_str(&xml_escape(&item.attendees.iter().map(|a| a.name.as_deref().unwrap_or(&a.email)).collect::<Vec<_>>().join("; ")));
+    xml.push_str(&xml_escape(
+        &item
+            .attendees
+            .iter()
+            .map(|a| a.name.as_deref().unwrap_or(&a.email))
+            .collect::<Vec<_>>()
+            .join("; "),
+    ));
     xml.push_str("</t:DisplayTo>");
-    xml.push_str(&format!("<t:LastModifiedName>{}</t:LastModifiedName>", xml_escape(item.organizer_name.as_deref().unwrap_or("Unknown"))));
-    xml.push_str(&format!("<t:LastModifiedTime>{}</t:LastModifiedTime>", item.dtstamp.unwrap_or_else(chrono::Utc::now).to_rfc3339()));
-    xml.push_str(&format!("<t:Size>{}</t:Size>", item.subject.len() + item.description.len() + item.location.len() + 512));
+    xml.push_str(&format!(
+        "<t:LastModifiedName>{}</t:LastModifiedName>",
+        xml_escape(item.organizer_name.as_deref().unwrap_or("Unknown"))
+    ));
+    xml.push_str(&format!(
+        "<t:LastModifiedTime>{}</t:LastModifiedTime>",
+        item.dtstamp.unwrap_or_else(chrono::Utc::now).to_rfc3339()
+    ));
+    xml.push_str(&format!(
+        "<t:Size>{}</t:Size>",
+        item.subject.len() + item.description.len() + item.location.len() + 512
+    ));
     xml.push_str("<t:EffectiveRights><t:CreateAssociated>false</t:CreateAssociated><t:CreateContents>true</t:CreateContents><t:CreateHierarchy>false</t:CreateHierarchy><t:Delete>true</t:Delete><t:Modify>true</t:Modify><t:Read>true</t:Read></t:EffectiveRights>");
     xml.push_str("</t:CalendarItem>");
     xml
 }
 
-fn render_ews_calendar_item_xml(item_id: &str, change_key: &str, item: &crate::calendar::CalendarItem) -> String {
+fn render_ews_calendar_item_xml(
+    item_id: &str,
+    change_key: &str,
+    item: &crate::calendar::CalendarItem,
+) -> String {
     render_ews_calendar_item_xml_with_shape(item_id, change_key, item, ItemShape::AllProperties)
 }
 
 async fn merged_freebusy_for_mailbox(
-    state: &Arc<AppState>, mailbox: &str, password: &str,
-    start: chrono::DateTime<chrono::Utc>, end: chrono::DateTime<chrono::Utc>, interval_minutes: i64,
+    state: &Arc<AppState>,
+    mailbox: &str,
+    password: &str,
+    start: chrono::DateTime<chrono::Utc>,
+    end: chrono::DateTime<chrono::Utc>,
+    interval_minutes: i64,
 ) -> (String, String) {
     let safe_interval = interval_minutes.clamp(5, 1440);
-    let slot_count = (((end - start).num_seconds().max(0) + (safe_interval * 60 - 1)) / (safe_interval * 60)) as usize;
+    let slot_count = (((end - start).num_seconds().max(0) + (safe_interval * 60 - 1))
+        / (safe_interval * 60)) as usize;
     let mut merged = vec!['0'; slot_count];
     let mut events_xml_out = String::new();
     let caldav = match CaldavClient::new(&state.cfg) {
@@ -681,8 +1204,15 @@ async fn merged_freebusy_for_mailbox(
     };
     if let Ok(calendars) = caldav.find_user_calendars(mailbox, password).await
         && let Some(collection_href) = calendars.first()
-        && let Ok(raw_events_xml) = caldav.query_events(collection_href,
-            &start.format("%Y%m%dT%H%M%SZ").to_string(), &end.format("%Y%m%dT%H%M%SZ").to_string(), mailbox, password).await
+        && let Ok(raw_events_xml) = caldav
+            .query_events(
+                collection_href,
+                &start.format("%Y%m%dT%H%M%SZ").to_string(),
+                &end.format("%Y%m%dT%H%M%SZ").to_string(),
+                mailbox,
+                password,
+            )
+            .await
     {
         let mut reader = Reader::from_str(&raw_events_xml);
         reader.config_mut().trim_text(true);
@@ -690,23 +1220,41 @@ async fn merged_freebusy_for_mailbox(
         let mut in_calendar_data = false;
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.name().local_name().as_ref() == b"calendar-data" => { in_calendar_data = true; }
+                Ok(Event::Start(e)) if e.name().local_name().as_ref() == b"calendar-data" => {
+                    in_calendar_data = true;
+                }
                 Ok(Event::Text(t)) if in_calendar_data => {
-                    if let Ok(ics) = t.decode() && let Some(item) = parse_ics_event(&ics) {
-                        let sd = match item.busy_status.unwrap_or(2) { 0 => '0', 1 => '1', 3 => '3', _ => '2' };
+                    if let Ok(ics) = t.decode()
+                        && let Some(item) = parse_ics_event(&ics)
+                    {
+                        let sd = match item.busy_status.unwrap_or(2) {
+                            0 => '0',
+                            1 => '1',
+                            3 => '3',
+                            _ => '2',
+                        };
                         for (i, slot) in merged.iter_mut().enumerate() {
                             let ss = start + chrono::Duration::minutes((i as i64) * safe_interval);
                             let se = ss + chrono::Duration::minutes(safe_interval);
-                            if item.start < se && item.end > ss && sd > *slot { *slot = sd; }
+                            if item.start < se && item.end > ss && sd > *slot {
+                                *slot = sd;
+                            }
                         }
-                        let busy_type = match item.busy_status.unwrap_or(2) { 0 => "Free", 1 => "Tentative", 3 => "OOF", _ => "Busy" };
+                        let busy_type = match item.busy_status.unwrap_or(2) {
+                            0 => "Free",
+                            1 => "Tentative",
+                            3 => "OOF",
+                            _ => "Busy",
+                        };
                         events_xml_out.push_str(&format!(
                             "<t:CalendarEvent><t:StartTime>{}</t:StartTime><t:EndTime>{}</t:EndTime><t:BusyType>{}</t:BusyType>{}</t:CalendarEvent>",
                             item.start.to_rfc3339(), item.end.to_rfc3339(), busy_type, ews_calendar_event_details_xml(&item)
                         ));
                     }
                 }
-                Ok(Event::End(e)) if e.name().local_name().as_ref() == b"calendar-data" => { in_calendar_data = false; }
+                Ok(Event::End(e)) if e.name().local_name().as_ref() == b"calendar-data" => {
+                    in_calendar_data = false;
+                }
                 Ok(Event::Eof) => break,
                 _ => {}
             }
@@ -718,35 +1266,61 @@ async fn merged_freebusy_for_mailbox(
     (merged.into_iter().collect(), events_xml_out)
 }
 
-fn suggestion_day_keys(start: chrono::DateTime<chrono::Utc>, end: chrono::DateTime<chrono::Utc>) -> Vec<String> {
-    if end <= start { return vec![start.format("%Y-%m-%d").to_string()]; }
+fn suggestion_day_keys(
+    start: chrono::DateTime<chrono::Utc>,
+    end: chrono::DateTime<chrono::Utc>,
+) -> Vec<String> {
+    if end <= start {
+        return vec![start.format("%Y-%m-%d").to_string()];
+    }
     let mut day = start.date_naive();
     let last = (end - chrono::Duration::seconds(1)).date_naive();
     let mut days = Vec::new();
     while day <= last {
         days.push(day.format("%Y-%m-%d").to_string());
-        let Some(next_day) = day.succ_opt() else { break; };
+        let Some(next_day) = day.succ_opt() else {
+            break;
+        };
         day = next_day;
     }
     days
 }
 
-fn suggestions_xml_for_window(merged: &str, start: chrono::DateTime<chrono::Utc>, end: chrono::DateTime<chrono::Utc>, slot_minutes: i64, meeting_minutes: i64) -> String {
+fn suggestions_xml_for_window(
+    merged: &str,
+    start: chrono::DateTime<chrono::Utc>,
+    end: chrono::DateTime<chrono::Utc>,
+    slot_minutes: i64,
+    meeting_minutes: i64,
+) -> String {
     let safe_slot = slot_minutes.clamp(5, 1440);
     let safe_meeting = meeting_minutes.clamp(safe_slot, 24 * 60);
     let slots_needed = ((safe_meeting + safe_slot - 1) / safe_slot) as usize;
     let mut day_buckets: std::collections::BTreeMap<String, Vec<String>> =
-        suggestion_day_keys(start, end).into_iter().map(|day| (day, Vec::new())).collect();
+        suggestion_day_keys(start, end)
+            .into_iter()
+            .map(|day| (day, Vec::new()))
+            .collect();
     let chars = merged.chars().collect::<Vec<_>>();
     for idx in 0..chars.len() {
-        if chars[idx] != '0' { continue; }
-        if idx + slots_needed > chars.len() || chars[idx..idx + slots_needed].iter().any(|c| *c != '0') { continue; }
+        if chars[idx] != '0' {
+            continue;
+        }
+        if idx + slots_needed > chars.len()
+            || chars[idx..idx + slots_needed].iter().any(|c| *c != '0')
+        {
+            continue;
+        }
         let slot_start = start + chrono::Duration::minutes((idx as i64) * safe_slot);
         let slot_end = slot_start + chrono::Duration::minutes(safe_meeting);
-        if slot_end > end { continue; }
+        if slot_end > end {
+            continue;
+        }
         let day_key = slot_start.format("%Y-%m-%d").to_string();
         let entry = day_buckets.entry(day_key).or_default();
-        if entry.len() >= 8 { continue; }
+        if entry.len() >= 8 {
+            continue;
+        }
         entry.push(format!("<t:Suggestion><t:MeetingTime>{}</t:MeetingTime><t:IsWorkTime>true</t:IsWorkTime><t:SuggestionQuality>Excellent</t:SuggestionQuality></t:Suggestion>", slot_start.to_rfc3339()));
     }
     let day_results = day_buckets.into_iter().map(|(day, suggestions)| {
@@ -754,10 +1328,13 @@ fn suggestions_xml_for_window(merged: &str, start: chrono::DateTime<chrono::Utc>
         format!("<t:SuggestionDayResult><t:Date>{}</t:Date><t:DayQuality>{}</t:DayQuality><t:SuggestionArray>{}</t:SuggestionArray></t:SuggestionDayResult>",
             day, quality, suggestions.join(""))
     }).collect::<String>();
-    format!(r#"<m:SuggestionsResponse>
+    format!(
+        r#"<m:SuggestionsResponse>
   <m:ResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:ResponseMessage>
   <m:SuggestionDayResultArray>{}</m:SuggestionDayResultArray>
-</m:SuggestionsResponse>"#, day_results)
+</m:SuggestionsResponse>"#,
+        day_results
+    )
 }
 
 fn merge_merged_freebusy(a: &str, b: &str) -> String {
@@ -774,7 +1351,12 @@ fn merge_merged_freebusy(a: &str, b: &str) -> String {
 }
 
 fn unauthorized() -> Response {
-    (StatusCode::UNAUTHORIZED, [("WWW-Authenticate", "Basic realm=\"EWS\"")], "Unauthorized").into_response()
+    (
+        StatusCode::UNAUTHORIZED,
+        [("WWW-Authenticate", "Basic realm=\"EWS\"")],
+        "Unauthorized",
+    )
+        .into_response()
 }
 
 fn soap_ok(inner: String) -> Response {
@@ -786,9 +1368,15 @@ fn soap_ok(inner: String) -> Response {
   </s:Header>
   <s:Body>{inner}</s:Body>
 </s:Envelope>"#,
-        type_ns = EWS_TYPE_NS, inner = inner
+        type_ns = EWS_TYPE_NS,
+        inner = inner
     );
-    (StatusCode::OK, [("Content-Type", "text/xml; charset=utf-8")], xml).into_response()
+    (
+        StatusCode::OK,
+        [("Content-Type", "text/xml; charset=utf-8")],
+        xml,
+    )
+        .into_response()
 }
 
 fn soap_fault(code: &str, message: &str, status: StatusCode) -> Response {
@@ -798,7 +1386,10 @@ fn soap_fault(code: &str, message: &str, status: StatusCode) -> Response {
   <s:Header><t:ServerVersionInfo MajorVersion="15" MinorVersion="20" MajorBuildNumber="0" MinorBuildNumber="0" Version="Exchange2016" xmlns:t="{type_ns}" /></s:Header>
   <s:Body><s:Fault><faultcode>s:Client</faultcode><faultstring>{}</faultstring><detail><m:ResponseCode xmlns:m="{}">{}</m:ResponseCode></detail></s:Fault></s:Body>
 </s:Envelope>"#,
-        xml_escape(message), EWS_MSG_NS, xml_escape(code), type_ns = EWS_TYPE_NS
+        xml_escape(message),
+        EWS_MSG_NS,
+        xml_escape(code),
+        type_ns = EWS_TYPE_NS
     );
     (status, [("Content-Type", "text/xml; charset=utf-8")], xml).into_response()
 }
@@ -810,55 +1401,123 @@ fn validate_requested_folder(action: &EwsAction, owner: &str, body: &str) -> Res
     let sync_id = extract_first_attr(body, b"SyncFolderId", b"Id");
 
     let all_owner_ids: Vec<String> = [
-        DistinguishedFolder::Calendar, DistinguishedFolder::MsgFolderRoot, DistinguishedFolder::Inbox,
-        DistinguishedFolder::SentItems, DistinguishedFolder::DeletedItems, DistinguishedFolder::Drafts,
-        DistinguishedFolder::Outbox, DistinguishedFolder::JunkEmail, DistinguishedFolder::Contacts,
-        DistinguishedFolder::Tasks, DistinguishedFolder::Notes, DistinguishedFolder::Journal,
-    ].iter().map(|&f| folder_id_for(owner, f)).collect();
+        DistinguishedFolder::Calendar,
+        DistinguishedFolder::MsgFolderRoot,
+        DistinguishedFolder::Inbox,
+        DistinguishedFolder::SentItems,
+        DistinguishedFolder::DeletedItems,
+        DistinguishedFolder::Drafts,
+        DistinguishedFolder::Outbox,
+        DistinguishedFolder::JunkEmail,
+        DistinguishedFolder::Contacts,
+        DistinguishedFolder::Tasks,
+        DistinguishedFolder::Notes,
+        DistinguishedFolder::Journal,
+    ]
+    .iter()
+    .map(|&f| folder_id_for(owner, f))
+    .collect();
 
     for maybe_id in [&explicit_id, &parent_id, &sync_id] {
-        if let Some(fid) = maybe_id {
-            if fid != "root" && !all_owner_ids.contains(fid) {
-                return Err(operation_error_response(action, "ErrorFolderNotFound", "Requested folder was not found for this mailbox", StatusCode::OK));
-            }
+        if let Some(fid) = maybe_id
+            && fid != "root"
+            && !all_owner_ids.contains(fid)
+        {
+            return Err(operation_error_response(
+                action,
+                "ErrorFolderNotFound",
+                "Requested folder was not found for this mailbox",
+                StatusCode::OK,
+            ));
         }
     }
 
-    if let Some(error_code) = validate_folder_request(owner, distinguished.as_deref(), explicit_id.as_deref(), sync_id.as_deref()) {
-        return Err(operation_error_response(action, error_code, "Requested folder was not found for this mailbox", StatusCode::OK));
+    if let Some(error_code) = validate_folder_request(
+        owner,
+        distinguished.as_deref(),
+        explicit_id.as_deref(),
+        sync_id.as_deref(),
+    ) {
+        return Err(operation_error_response(
+            action,
+            error_code,
+            "Requested folder was not found for this mailbox",
+            StatusCode::OK,
+        ));
     }
     Ok(())
 }
 
-struct CurrentCalendarItem { row: EwsItemRow, item: crate::calendar::CalendarItem }
+struct CurrentCalendarItem {
+    row: EwsItemRow,
+    item: crate::calendar::CalendarItem,
+}
 
-fn parse_calendar_view_window(body: &str) -> Option<(chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>)> {
-    let start = extract_first_attr(body, b"CalendarView", b"StartDate").and_then(|v| crate::calendar::parse_datetime(&v));
-    let end = extract_first_attr(body, b"CalendarView", b"EndDate").and_then(|v| crate::calendar::parse_datetime(&v));
-    match (start, end) { (Some(s), Some(e)) if e > s => Some((s, e)), _ => None }
+fn parse_calendar_view_window(
+    body: &str,
+) -> Option<(chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>)> {
+    let start = extract_first_attr(body, b"CalendarView", b"StartDate")
+        .and_then(|v| crate::calendar::parse_datetime(&v));
+    let end = extract_first_attr(body, b"CalendarView", b"EndDate")
+        .and_then(|v| crate::calendar::parse_datetime(&v));
+    match (start, end) {
+        (Some(s), Some(e)) if e > s => Some((s, e)),
+        _ => None,
+    }
 }
 
 fn requested_freebusy_view_type(body: &str) -> &'static str {
-    match extract_first_tag_text(body, b"RequestedView").unwrap_or_else(|| "MergedOnly".to_string()).to_ascii_lowercase().as_str() {
-        "freebusy" => "FreeBusy", "freebusydetailed" => "Detailed", "detailedmerged" => "DetailedMerged", _ => "MergedOnly",
+    match extract_first_tag_text(body, b"RequestedView")
+        .unwrap_or_else(|| "MergedOnly".to_string())
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "freebusy" => "FreeBusy",
+        "freebusydetailed" => "Detailed",
+        "detailedmerged" => "DetailedMerged",
+        _ => "MergedOnly",
     }
 }
 
 fn requested_item_shape(body: &str) -> ItemShape {
-    match extract_first_tag_text(body, b"BaseShape").unwrap_or_else(|| "AllProperties".to_string()).to_ascii_lowercase().as_str() {
-        "idonly" => ItemShape::IdOnly, "default" => ItemShape::Default, _ => ItemShape::AllProperties,
+    match extract_first_tag_text(body, b"BaseShape")
+        .unwrap_or_else(|| "AllProperties".to_string())
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "idonly" => ItemShape::IdOnly,
+        "default" => ItemShape::Default,
+        _ => ItemShape::AllProperties,
     }
 }
 
 async fn load_current_calendar_items(
-    state: &Arc<AppState>, owner: &str, password: &str,
+    state: &Arc<AppState>,
+    owner: &str,
+    password: &str,
     window: Option<(chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>)>,
 ) -> Result<Vec<CurrentCalendarItem>, anyhow::Error> {
     let caldav = CaldavClient::new(&state.cfg)?;
     let calendars = caldav.find_user_calendars(owner, password).await?;
-    let collection_href = calendars.first().ok_or_else(|| anyhow::anyhow!("no calendars found"))?.clone();
-    let (start, end) = window.unwrap_or_else(|| (chrono::Utc::now() - chrono::Duration::weeks(104), chrono::Utc::now() + chrono::Duration::weeks(104)));
-    let events_xml = caldav.query_events(&collection_href, &start.format("%Y%m%dT%H%M%SZ").to_string(), &end.format("%Y%m%dT%H%M%SZ").to_string(), owner, password).await?;
+    let collection_href = calendars
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("no calendars found"))?
+        .clone();
+    let (start, end) = window.unwrap_or_else(|| {
+        (
+            chrono::Utc::now() - chrono::Duration::weeks(104),
+            chrono::Utc::now() + chrono::Duration::weeks(104),
+        )
+    });
+    let events_xml = caldav
+        .query_events(
+            &collection_href,
+            &start.format("%Y%m%dT%H%M%SZ").to_string(),
+            &end.format("%Y%m%dT%H%M%SZ").to_string(),
+            owner,
+            password,
+        )
+        .await?;
     let mut reader = Reader::from_str(&events_xml);
     reader.config_mut().trim_text(true);
     let mut buf = Vec::new();
@@ -869,24 +1528,60 @@ async fn load_current_calendar_items(
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => match e.name().local_name().as_ref() {
-                b"href" => { if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) { href = t.decode().unwrap_or_default().to_string(); } }
-                b"getetag" => { if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) { etag = t.decode().unwrap_or_default().trim_matches('"').to_string(); } }
-                b"calendar-data" => { if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) { ics = t.decode().unwrap_or_default().to_string(); } }
+                b"href" => {
+                    if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) {
+                        href = t.decode().unwrap_or_default().to_string();
+                    }
+                }
+                b"getetag" => {
+                    if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) {
+                        etag = t.decode().unwrap_or_default().trim_matches('"').to_string();
+                    }
+                }
+                b"calendar-data" => {
+                    if let Ok(Event::Text(t)) = reader.read_event_into(&mut buf) {
+                        ics = t.decode().unwrap_or_default().to_string();
+                    }
+                }
                 _ => {}
             },
             Ok(Event::End(ref e)) if e.name().local_name().as_ref() == b"response" => {
-                if !href.is_empty() && let Some(item) = parse_ics_event(&ics) {
+                if !href.is_empty()
+                    && let Some(item) = parse_ics_event(&ics)
+                {
                     let server_id = generate_server_id(state.cfg.hmac_secret(), &href);
                     let safe_etag = if etag.is_empty() {
-                        let mut h = Sha256::new(); h.update(server_id.as_bytes()); h.finalize().iter().map(|b| format!("{:02x}", b)).collect()
-                    } else { etag.clone() };
-                    let _ = state.storage.upsert_item_map(owner, &collection_href, &href, &server_id, &item.uid, &safe_etag).await;
+                        let mut h = Sha256::new();
+                        h.update(server_id.as_bytes());
+                        h.finalize().iter().map(|b| format!("{:02x}", b)).collect()
+                    } else {
+                        etag.clone()
+                    };
+                    let _ = state
+                        .storage
+                        .upsert_item_map(
+                            owner,
+                            &collection_href,
+                            &href,
+                            &server_id,
+                            &item.uid,
+                            &safe_etag,
+                        )
+                        .await;
                     out.push(CurrentCalendarItem {
-                        row: EwsItemRow { server_id, resource_href: href.clone(), uid: Some(item.uid.clone()), etag: Some(safe_etag), updated_at: None },
+                        row: EwsItemRow {
+                            server_id,
+                            resource_href: href.clone(),
+                            uid: Some(item.uid.clone()),
+                            etag: Some(safe_etag),
+                            updated_at: None,
+                        },
                         item,
                     });
                 }
-                href.clear(); etag.clear(); ics.clear();
+                href.clear();
+                etag.clear();
+                ics.clear();
             }
             Ok(Event::Eof) => break,
             _ => {}
@@ -898,12 +1593,23 @@ async fn load_current_calendar_items(
 
 async fn handle_get_folder(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
     let owner = owner_from_username(&auth.username);
-    if let Err(resp) = validate_requested_folder(&EwsAction::GetFolder, owner, body) { return resp; }
-    let distinguished_str = extract_first_attr(body, b"DistinguishedFolderId", b"Id").unwrap_or_default().to_ascii_lowercase();
-    let folder = DistinguishedFolder::from_str(&distinguished_str).unwrap_or(DistinguishedFolder::Calendar);
-    let total_count = if folder.is_calendar() || matches!(folder, DistinguishedFolder::MsgFolderRoot) {
-        load_current_calendar_items(state, owner, &auth.password, None).await.map(|v| v.len()).unwrap_or(0)
-    } else { 0 };
+    if let Err(resp) = validate_requested_folder(&EwsAction::GetFolder, owner, body) {
+        return resp;
+    }
+    let distinguished_str = extract_first_attr(body, b"DistinguishedFolderId", b"Id")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let folder =
+        DistinguishedFolder::from_str(&distinguished_str).unwrap_or(DistinguishedFolder::Calendar);
+    let total_count =
+        if folder.is_calendar() || matches!(folder, DistinguishedFolder::MsgFolderRoot) {
+            load_current_calendar_items(state, owner, &auth.password, None)
+                .await
+                .map(|v| v.len())
+                .unwrap_or(0)
+        } else {
+            0
+        };
     let folders_xml = render_folder_xml(owner, folder, total_count);
     let response = format!(
         r#"<m:GetFolderResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:GetFolderResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Folders>{}</m:Folders></m:GetFolderResponseMessage></m:ResponseMessages></m:GetFolderResponse>"#,
@@ -914,12 +1620,22 @@ async fn handle_get_folder(state: &Arc<AppState>, auth: &AuthContext, body: &str
 
 async fn handle_find_folder(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
     let owner = owner_from_username(&auth.username);
-    if let Err(resp) = validate_requested_folder(&EwsAction::FindFolder, owner, body) { return resp; }
-    let distinguished_str = extract_first_attr(body, b"DistinguishedFolderId", b"Id").unwrap_or_default().to_ascii_lowercase();
+    if let Err(resp) = validate_requested_folder(&EwsAction::FindFolder, owner, body) {
+        return resp;
+    }
+    let distinguished_str = extract_first_attr(body, b"DistinguishedFolderId", b"Id")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
     let (total_count, cal_xml) = match distinguished_str.as_str() {
         "msgfolderroot" | "" => {
-            let count = load_current_calendar_items(state, owner, &auth.password, None).await.map(|v| v.len()).unwrap_or(0);
-            (1usize, render_folder_xml(owner, DistinguishedFolder::Calendar, count))
+            let count = load_current_calendar_items(state, owner, &auth.password, None)
+                .await
+                .map(|v| v.len())
+                .unwrap_or(0);
+            (
+                1usize,
+                render_folder_xml(owner, DistinguishedFolder::Calendar, count),
+            )
         }
         _ => (0usize, String::new()),
     };
@@ -932,17 +1648,41 @@ async fn handle_find_folder(state: &Arc<AppState>, auth: &AuthContext, body: &st
 
 async fn handle_find_item(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
     let owner = owner_from_username(&auth.username);
-    if let Err(resp) = validate_requested_folder(&EwsAction::FindItem, owner, body) { return resp; }
+    if let Err(resp) = validate_requested_folder(&EwsAction::FindItem, owner, body) {
+        return resp;
+    }
     let max = extract_int(body, b"MaxEntriesReturned", 50);
     let offset = extract_int(body, b"Offset", 0);
-    let traversal = extract_first_attr(body, b"IndexedPageItemView", b"BasePoint").unwrap_or_else(|| "Beginning".to_string());
-    if max == 0 || max > 512 { return operation_error_response(&EwsAction::FindItem, "ErrorInvalidPagingMaxRows", "MaxEntriesReturned must be between 1 and 512", StatusCode::OK); }
-    if traversal != "Beginning" { return operation_error_response(&EwsAction::FindItem, "ErrorInvalidIndexedPagingParameters", "Only IndexedPageItemView BasePoint=Beginning is supported", StatusCode::OK); }
+    let traversal = extract_first_attr(body, b"IndexedPageItemView", b"BasePoint")
+        .unwrap_or_else(|| "Beginning".to_string());
+    if max == 0 || max > 512 {
+        return operation_error_response(
+            &EwsAction::FindItem,
+            "ErrorInvalidPagingMaxRows",
+            "MaxEntriesReturned must be between 1 and 512",
+            StatusCode::OK,
+        );
+    }
+    if traversal != "Beginning" {
+        return operation_error_response(
+            &EwsAction::FindItem,
+            "ErrorInvalidIndexedPagingParameters",
+            "Only IndexedPageItemView BasePoint=Beginning is supported",
+            StatusCode::OK,
+        );
+    }
     let view_window = parse_calendar_view_window(body);
     let shape = requested_item_shape(body);
     let items = match load_current_calendar_items(state, owner, &auth.password, view_window).await {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::FindItem, "ErrorInternalServerError", &format!("Failed to query items: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::FindItem,
+                "ErrorInternalServerError",
+                &format!("Failed to query items: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
     let folder_id = folder_id_for_owner(owner);
     let total_items = items.len();
@@ -950,11 +1690,23 @@ async fn handle_find_item(state: &Arc<AppState>, auth: &AuthContext, body: &str)
     let mut item_xml = String::new();
     for current in &paged {
         let ck = changekey_for_item(&current.row);
-        item_xml.push_str(&render_ews_calendar_item_xml_with_shape(&current.row.server_id, &ck, &current.item, shape));
+        item_xml.push_str(&render_ews_calendar_item_xml_with_shape(
+            &current.row.server_id,
+            &ck,
+            &current.item,
+            shape,
+        ));
     }
-    let includes_last = if offset + paged.len() >= total_items { "true" } else { "false" };
+    let includes_last = if offset + paged.len() >= total_items {
+        "true"
+    } else {
+        "false"
+    };
     let next_offset = offset + paged.len();
-    let _ = state.storage.set_ews_sync_state(owner, &folder_id, &format!("offset:{}", next_offset)).await;
+    let _ = state
+        .storage
+        .set_ews_sync_state(owner, &folder_id, &format!("offset:{}", next_offset))
+        .await;
     let response = format!(
         r#"<m:FindItemResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:FindItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder TotalItemsInView="{}" IncludesLastItemInRange="{}" IndexedPagingOffset="{}"><t:Items>{}</t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse>"#,
         EWS_MSG_NS, EWS_TYPE_NS, total_items, includes_last, next_offset, item_xml
@@ -965,26 +1717,71 @@ async fn handle_find_item(state: &Arc<AppState>, auth: &AuthContext, body: &str)
 async fn handle_get_item(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
     let owner = owner_from_username(&auth.username);
     let item_id = extract_first_attr(body, b"ItemId", b"Id").unwrap_or_default();
-    if item_id.is_empty() { return operation_error_response(&EwsAction::GetItem, "ErrorInvalidIdMalformed", "GetItem requires ItemId/@Id", StatusCode::OK); }
-    let item = match state.storage.get_ews_item_by_server_id(owner, &item_id).await {
+    if item_id.is_empty() {
+        return operation_error_response(
+            &EwsAction::GetItem,
+            "ErrorInvalidIdMalformed",
+            "GetItem requires ItemId/@Id",
+            StatusCode::OK,
+        );
+    }
+    let item = match state
+        .storage
+        .get_ews_item_by_server_id(owner, &item_id)
+        .await
+    {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::GetItem, "ErrorInternalServerError", &format!("Failed to load item: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::GetItem,
+                "ErrorInternalServerError",
+                &format!("Failed to load item: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    let Some(item) = item else { return operation_error_response(&EwsAction::GetItem, "ErrorItemNotFound", "Requested item does not exist", StatusCode::OK); };
+    let Some(item) = item else {
+        return operation_error_response(
+            &EwsAction::GetItem,
+            "ErrorItemNotFound",
+            "Requested item does not exist",
+            StatusCode::OK,
+        );
+    };
     let ck = changekey_for_item(&item);
     let shape = requested_item_shape(body);
     let caldav = match CaldavClient::new(&state.cfg) {
         Ok(c) => c,
-        Err(e) => return operation_error_response(&EwsAction::GetItem, "ErrorInternalServerError", &format!("Failed to create CalDAV client: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::GetItem,
+                "ErrorInternalServerError",
+                &format!("Failed to create CalDAV client: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    let calendar_item_xml = match caldav.get_event(&item.resource_href, owner, &auth.password).await {
+    let calendar_item_xml = match caldav
+        .get_event(&item.resource_href, owner, &auth.password)
+        .await
+    {
         Ok((ics, _)) => match parse_ics_event(&ics) {
             Some(ci) => render_ews_calendar_item_xml_with_shape(&item.server_id, &ck, &ci, shape),
-            None => format!(r#"<t:CalendarItem><t:ItemId Id="{}" ChangeKey="{}" /><t:Subject>{}</t:Subject><t:UID>{}</t:UID></t:CalendarItem>"#,
-                xml_escape(&item.server_id), xml_escape(&ck), xml_escape(item.uid.as_deref().unwrap_or(&item.server_id)), xml_escape(item.uid.as_deref().unwrap_or(&item.server_id))),
+            None => format!(
+                r#"<t:CalendarItem><t:ItemId Id="{}" ChangeKey="{}" /><t:Subject>{}</t:Subject><t:UID>{}</t:UID></t:CalendarItem>"#,
+                xml_escape(&item.server_id),
+                xml_escape(&ck),
+                xml_escape(item.uid.as_deref().unwrap_or(&item.server_id)),
+                xml_escape(item.uid.as_deref().unwrap_or(&item.server_id))
+            ),
         },
-        Err(_) => format!(r#"<t:CalendarItem><t:ItemId Id="{}" ChangeKey="{}" /><t:Subject>{}</t:Subject><t:UID>{}</t:UID></t:CalendarItem>"#,
-            xml_escape(&item.server_id), xml_escape(&ck), xml_escape(item.uid.as_deref().unwrap_or(&item.server_id)), xml_escape(item.uid.as_deref().unwrap_or(&item.server_id))),
+        Err(_) => format!(
+            r#"<t:CalendarItem><t:ItemId Id="{}" ChangeKey="{}" /><t:Subject>{}</t:Subject><t:UID>{}</t:UID></t:CalendarItem>"#,
+            xml_escape(&item.server_id),
+            xml_escape(&ck),
+            xml_escape(item.uid.as_deref().unwrap_or(&item.server_id)),
+            xml_escape(item.uid.as_deref().unwrap_or(&item.server_id))
+        ),
     };
     let response = format!(
         r#"<m:GetItemResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items>{}</m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse>"#,
@@ -1005,7 +1802,9 @@ fn decode_sync_state_cursor(marker: &str) -> Result<(i64, i64), ()> {
     let mut parts = rest.split(':');
     let last_seen = parts.next().ok_or(())?.parse::<i64>().map_err(|_| ())?;
     let upper_bound = parts.next().ok_or(())?.parse::<i64>().map_err(|_| ())?;
-    if parts.next().is_some() { return Err(()); }
+    if parts.next().is_some() {
+        return Err(());
+    }
     Ok((last_seen.max(0), upper_bound.max(last_seen)))
 }
 
@@ -1017,72 +1816,167 @@ fn parse_sync_state_marker(marker: Option<String>) -> Result<(i64, i64), ()> {
     }
 }
 
-async fn handle_sync_folder_items(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
+async fn handle_sync_folder_items(
+    state: &Arc<AppState>,
+    auth: &AuthContext,
+    body: &str,
+) -> Response {
     let owner = owner_from_username(&auth.username);
-    if let Err(resp) = validate_requested_folder(&EwsAction::SyncFolderItems, owner, body) { return resp; }
+    if let Err(resp) = validate_requested_folder(&EwsAction::SyncFolderItems, owner, body) {
+        return resp;
+    }
     let max_changes = extract_int(body, b"MaxChangesReturned", 100);
     let shape = requested_item_shape(body);
     let folder_id = folder_id_for_owner(owner);
-    if max_changes == 0 || max_changes > 512 { return operation_error_response(&EwsAction::SyncFolderItems, "ErrorInvalidPagingMaxRows", "MaxChangesReturned must be between 1 and 512", StatusCode::OK); }
+    if max_changes == 0 || max_changes > 512 {
+        return operation_error_response(
+            &EwsAction::SyncFolderItems,
+            "ErrorInvalidPagingMaxRows",
+            "MaxChangesReturned must be between 1 and 512",
+            StatusCode::OK,
+        );
+    }
     let requested_state = extract_first_tag_text(body, b"SyncState");
     let effective_state = if requested_state.as_deref().unwrap_or("0").is_empty() {
-        match state.storage.get_ews_sync_state(owner, &folder_id).await { Ok(v) => v, Err(_) => None }
-    } else { requested_state };
+        match state.storage.get_ews_sync_state(owner, &folder_id).await {
+            Ok(v) => v,
+            Err(_) => None,
+        }
+    } else {
+        requested_state
+    };
     let (since, requested_upper_bound) = match parse_sync_state_marker(effective_state) {
         Ok(v) => v,
-        Err(_) => return operation_error_response(&EwsAction::SyncFolderItems, "ErrorInvalidSyncStateData", "SyncState is invalid; expected an opaque base64-encoded gateway sync blob", StatusCode::OK),
+        Err(_) => {
+            return operation_error_response(
+                &EwsAction::SyncFolderItems,
+                "ErrorInvalidSyncStateData",
+                "SyncState is invalid; expected an opaque base64-encoded gateway sync blob",
+                StatusCode::OK,
+            );
+        }
     };
     let latest_seq = state.storage.get_latest_change_seq().await.unwrap_or(0);
-    let upper_bound = if requested_upper_bound > since { requested_upper_bound.min(latest_seq) } else { latest_seq };
-    let journal_rows = match state.storage.list_journal_since_seq(owner, since, upper_bound, max_changes.saturating_add(1)).await {
+    let upper_bound = if requested_upper_bound > since {
+        requested_upper_bound.min(latest_seq)
+    } else {
+        latest_seq
+    };
+    let journal_rows = match state
+        .storage
+        .list_journal_since_seq(owner, since, upper_bound, max_changes.saturating_add(1))
+        .await
+    {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::SyncFolderItems, "ErrorInternalServerError", &format!("Failed to query change journal: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::SyncFolderItems,
+                "ErrorInternalServerError",
+                &format!("Failed to query change journal: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
     let items = match load_current_calendar_items(state, owner, &auth.password, None).await {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::SyncFolderItems, "ErrorInternalServerError", &format!("Failed to query current items: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::SyncFolderItems,
+                "ErrorInternalServerError",
+                &format!("Failed to query current items: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
     let mut current_map = HashMap::new();
-    for item in items { current_map.insert(item.row.server_id.clone(), item); }
+    for item in items {
+        current_map.insert(item.row.server_id.clone(), item);
+    }
     let has_more = journal_rows.len() > max_changes;
-    let visible_rows = if has_more { &journal_rows[..max_changes] } else { &journal_rows[..] };
+    let visible_rows = if has_more {
+        &journal_rows[..max_changes]
+    } else {
+        &journal_rows[..]
+    };
     let mut emitted_ids = HashSet::new();
     let mut changes_xml = String::new();
     let mut last_returned_seq = since;
     for row in visible_rows {
         last_returned_seq = row.seq;
-        if !emitted_ids.insert(row.server_id.clone()) { continue; }
+        if !emitted_ids.insert(row.server_id.clone()) {
+            continue;
+        }
         if row.op == "delete" {
-            changes_xml.push_str(&format!(r#"<t:Delete><t:ItemId Id="{}" /></t:Delete>"#, xml_escape(&row.server_id)));
+            changes_xml.push_str(&format!(
+                r#"<t:Delete><t:ItemId Id="{}" /></t:Delete>"#,
+                xml_escape(&row.server_id)
+            ));
             continue;
         }
         if let Some(item) = current_map.get(&row.server_id) {
             let ck = changekey_for_item(&item.row);
             let change_tag = if since == 0 { "Create" } else { "Update" };
-            changes_xml.push_str(&format!(r#"<t:{ct}>{}</t:{ct}>"#, render_ews_calendar_item_xml_with_shape(&item.row.server_id, &ck, &item.item, shape), ct = change_tag));
+            changes_xml.push_str(&format!(
+                r#"<t:{ct}>{}</t:{ct}>"#,
+                render_ews_calendar_item_xml_with_shape(
+                    &item.row.server_id,
+                    &ck,
+                    &item.item,
+                    shape
+                ),
+                ct = change_tag
+            ));
         }
     }
     let includes_last = if has_more { "false" } else { "true" };
-    let next_seen_seq = if visible_rows.is_empty() { since.max(upper_bound) } else { last_returned_seq };
-    let next_upper_bound = if includes_last == "true" { next_seen_seq } else { upper_bound };
+    let next_seen_seq = if visible_rows.is_empty() {
+        since.max(upper_bound)
+    } else {
+        last_returned_seq
+    };
+    let next_upper_bound = if includes_last == "true" {
+        next_seen_seq
+    } else {
+        upper_bound
+    };
     let new_sync_state = encode_sync_state_cursor(next_seen_seq, next_upper_bound);
-    let _ = state.storage.set_ews_sync_state(owner, &folder_id, &new_sync_state).await;
+    let _ = state
+        .storage
+        .set_ews_sync_state(owner, &folder_id, &new_sync_state)
+        .await;
     let response = format!(
         r#"<m:SyncFolderItemsResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:SyncFolderItemsResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:SyncState>{}</m:SyncState><m:IncludesLastItemInRange>{}</m:IncludesLastItemInRange><m:Changes>{}</m:Changes></m:SyncFolderItemsResponseMessage></m:ResponseMessages></m:SyncFolderItemsResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, xml_escape(&new_sync_state), includes_last, changes_xml
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        xml_escape(&new_sync_state),
+        includes_last,
+        changes_xml
     );
     soap_ok(response)
 }
 
-async fn handle_sync_folder_hierarchy(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
+async fn handle_sync_folder_hierarchy(
+    state: &Arc<AppState>,
+    auth: &AuthContext,
+    body: &str,
+) -> Response {
     let owner = owner_from_username(&auth.username);
     let sync_state_key = format!("{}/folderhierarchy", owner);
     let requested_state = extract_first_tag_text(body, b"SyncState");
-    let is_initial = requested_state.as_deref().map(|s| s.is_empty()).unwrap_or(true);
+    let is_initial = requested_state
+        .as_deref()
+        .map(|s| s.is_empty())
+        .unwrap_or(true);
     let new_sync_state = encode_sync_state_cursor(0, 0);
-    let _ = state.storage.set_ews_sync_state(owner, &sync_state_key, &new_sync_state).await;
+    let _ = state
+        .storage
+        .set_ews_sync_state(owner, &sync_state_key, &new_sync_state)
+        .await;
     let changes = if is_initial {
-        let count = load_current_calendar_items(state, owner, &auth.password, None).await.map(|v| v.len()).unwrap_or(0);
+        let count = load_current_calendar_items(state, owner, &auth.password, None)
+            .await
+            .map(|v| v.len())
+            .unwrap_or(0);
         let cal_xml = render_folder_xml(owner, DistinguishedFolder::Calendar, count);
         format!("<t:Create>{}</t:Create>", cal_xml)
     } else {
@@ -1090,7 +1984,10 @@ async fn handle_sync_folder_hierarchy(state: &Arc<AppState>, auth: &AuthContext,
     };
     let response = format!(
         r#"<m:SyncFolderHierarchyResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:SyncFolderHierarchyResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:SyncState>{}</m:SyncState><m:IncludesLastFolderInRange>true</m:IncludesLastFolderInRange><m:Changes>{}</m:Changes></m:SyncFolderHierarchyResponseMessage></m:ResponseMessages></m:SyncFolderHierarchyResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, xml_escape(&new_sync_state), changes
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        xml_escape(&new_sync_state),
+        changes
     );
     soap_ok(response)
 }
@@ -1100,7 +1997,10 @@ async fn handle_subscribe(_auth: &AuthContext, _body: &str) -> Response {
     let watermark = STANDARD.encode(subscription_id.as_bytes());
     let response = format!(
         r#"<m:SubscribeResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:SubscribeResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:SubscriptionId>{}</m:SubscriptionId><m:Watermark>{}</m:Watermark></m:SubscribeResponseMessage></m:ResponseMessages></m:SubscribeResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, xml_escape(&subscription_id), xml_escape(&watermark)
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        xml_escape(&subscription_id),
+        xml_escape(&watermark)
     );
     soap_ok(response)
 }
@@ -1115,33 +2015,86 @@ async fn handle_unsubscribe(_auth: &AuthContext, _body: &str) -> Response {
 
 async fn handle_create_item(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
     let owner = owner_from_username(&auth.username);
-    if let Err(resp) = validate_requested_folder(&EwsAction::CreateItem, owner, body) { return resp; }
+    if let Err(resp) = validate_requested_folder(&EwsAction::CreateItem, owner, body) {
+        return resp;
+    }
     let caldav = match CaldavClient::new(&state.cfg) {
         Ok(c) => c,
-        Err(e) => return operation_error_response(&EwsAction::GetItem, "ErrorInternalServerError", &format!("Failed to create CalDAV client: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::GetItem,
+                "ErrorInternalServerError",
+                &format!("Failed to create CalDAV client: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
     let item = match parse_ews_calendar_item(body) {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::CreateItem, "ErrorSchemaValidation", &format!("Failed to parse CalendarItem payload: {e}"), StatusCode::BAD_REQUEST),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::CreateItem,
+                "ErrorSchemaValidation",
+                &format!("Failed to parse CalendarItem payload: {e}"),
+                StatusCode::BAD_REQUEST,
+            );
+        }
     };
-    let calendars = match caldav.find_user_calendars(owner, &auth.password).await { Ok(v) => v, Err(_) => Vec::new() };
+    let calendars = match caldav.find_user_calendars(owner, &auth.password).await {
+        Ok(v) => v,
+        Err(_) => Vec::new(),
+    };
     let collection_href = match calendars.first() {
         Some(v) => v.clone(),
-        None => return operation_error_response(&EwsAction::CreateItem, "ErrorFolderNotFound", "No writable calendar collection discovered", StatusCode::OK),
+        None => {
+            return operation_error_response(
+                &EwsAction::CreateItem,
+                "ErrorFolderNotFound",
+                "No writable calendar collection discovered",
+                StatusCode::OK,
+            );
+        }
     };
     let ics = render_ics(&item);
-    let (href, etag) = match caldav.put_event(&collection_href, None, &ics, owner, &auth.password, None).await {
+    let (href, etag) = match caldav
+        .put_event(&collection_href, None, &ics, owner, &auth.password, None)
+        .await
+    {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::CreateItem, "ErrorInternalServerError", &format!("Failed to persist created item: {e}"), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::CreateItem,
+                "ErrorInternalServerError",
+                &format!("Failed to persist created item: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
     let server_id = generate_server_id(state.cfg.hmac_secret(), &href);
-    if let Err(e) = state.storage.upsert_item_map(owner, &collection_href, &href, &server_id, &item.uid, &etag).await {
-        return operation_error_response(&EwsAction::CreateItem, "ErrorInternalServerError", &format!("Failed to persist created item: {}", e), StatusCode::INTERNAL_SERVER_ERROR);
+    if let Err(e) = state
+        .storage
+        .upsert_item_map(owner, &collection_href, &href, &server_id, &item.uid, &etag)
+        .await
+    {
+        return operation_error_response(
+            &EwsAction::CreateItem,
+            "ErrorInternalServerError",
+            &format!("Failed to persist created item: {}", e),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
     }
-    let response_row = EwsItemRow { server_id: server_id.clone(), resource_href: href, uid: Some(item.uid.clone()), etag: Some(etag), updated_at: None };
+    let response_row = EwsItemRow {
+        server_id: server_id.clone(),
+        resource_href: href,
+        uid: Some(item.uid.clone()),
+        etag: Some(etag),
+        updated_at: None,
+    };
     let response = format!(
         r#"<m:CreateItemResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:CreateItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items>{}</m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, render_ews_calendar_item_xml(&server_id, &changekey_for_item(&response_row), &item)
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        render_ews_calendar_item_xml(&server_id, &changekey_for_item(&response_row), &item)
     );
     soap_ok(response)
 }
@@ -1149,70 +2102,221 @@ async fn handle_create_item(state: &Arc<AppState>, auth: &AuthContext, body: &st
 async fn handle_update_item(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
     let owner = owner_from_username(&auth.username);
     let item_id = extract_first_attr(body, b"ItemId", b"Id").unwrap_or_default();
-    if item_id.is_empty() { return operation_error_response(&EwsAction::UpdateItem, "ErrorInvalidIdMalformed", "UpdateItem requires ItemId/@Id", StatusCode::OK); }
-    let stored_item = match state.storage.get_ews_item_by_server_id(owner, &item_id).await {
+    if item_id.is_empty() {
+        return operation_error_response(
+            &EwsAction::UpdateItem,
+            "ErrorInvalidIdMalformed",
+            "UpdateItem requires ItemId/@Id",
+            StatusCode::OK,
+        );
+    }
+    let stored_item = match state
+        .storage
+        .get_ews_item_by_server_id(owner, &item_id)
+        .await
+    {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::UpdateItem, "ErrorInternalServerError", &format!("Failed to load item: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::UpdateItem,
+                "ErrorInternalServerError",
+                &format!("Failed to load item: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    let Some(stored_item) = stored_item else { return operation_error_response(&EwsAction::UpdateItem, "ErrorItemNotFound", "Requested item does not exist", StatusCode::OK); };
-    if let Err(resp) = validate_item_change_key(&EwsAction::UpdateItem, body, &stored_item) { return resp; }
+    let Some(stored_item) = stored_item else {
+        return operation_error_response(
+            &EwsAction::UpdateItem,
+            "ErrorItemNotFound",
+            "Requested item does not exist",
+            StatusCode::OK,
+        );
+    };
+    if let Err(resp) = validate_item_change_key(&EwsAction::UpdateItem, body, &stored_item) {
+        return resp;
+    }
     let caldav = match CaldavClient::new(&state.cfg) {
         Ok(c) => c,
-        Err(e) => return operation_error_response(&EwsAction::GetItem, "ErrorInternalServerError", &format!("Failed to create CalDAV client: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::GetItem,
+                "ErrorInternalServerError",
+                &format!("Failed to create CalDAV client: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    let (existing_ics, existing_etag) = match caldav.get_event(&stored_item.resource_href, owner, &auth.password).await {
+    let (existing_ics, existing_etag) = match caldav
+        .get_event(&stored_item.resource_href, owner, &auth.password)
+        .await
+    {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::UpdateItem, "ErrorInternalServerError", &format!("Failed to fetch existing event: {e}"), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::UpdateItem,
+                "ErrorInternalServerError",
+                &format!("Failed to fetch existing event: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    let mut current_item = parse_ics_event(&existing_ics).unwrap_or_else(|| crate::calendar::CalendarItem {
-        uid: stored_item.uid.clone().unwrap_or_else(|| stored_item.server_id.clone()),
-        start: chrono::Utc::now(), end: chrono::Utc::now() + chrono::Duration::hours(1),
-        dtstamp: Some(chrono::Utc::now()), ..Default::default()
-    });
+    let mut current_item =
+        parse_ics_event(&existing_ics).unwrap_or_else(|| crate::calendar::CalendarItem {
+            uid: stored_item
+                .uid
+                .clone()
+                .unwrap_or_else(|| stored_item.server_id.clone()),
+            start: chrono::Utc::now(),
+            end: chrono::Utc::now() + chrono::Duration::hours(1),
+            dtstamp: Some(chrono::Utc::now()),
+            ..Default::default()
+        });
     let field_changes = parse_item_changes(body);
     if !field_changes.is_empty() {
         apply_field_changes(&mut current_item, &field_changes);
     } else {
-        if let Some(v) = extract_ews_field(body, b"Subject").or_else(|| extract_ews_field(body, b"Value")) { current_item.subject = v; }
-        if let Some(v) = extract_ews_field(body, b"Start").and_then(|v| crate::calendar::parse_datetime(&v)) { current_item.start = v; }
-        if let Some(v) = extract_ews_field(body, b"End").and_then(|v| crate::calendar::parse_datetime(&v)) { current_item.end = v; }
-        if let Some(v) = extract_ews_field(body, b"Location") { current_item.location = v; }
-        if let Some(v) = extract_ews_field(body, b"Body").or_else(|| extract_ews_field(body, b"TextBody")) { current_item.description = v; }
-        if body.contains("Categories") { current_item.categories = extract_ews_fields(body, b"String"); }
-        if let Some(v) = extract_ews_field(body, b"ReminderMinutesBeforeStart").and_then(|v| v.parse().ok()) { current_item.reminder = Some(v); }
+        if let Some(v) =
+            extract_ews_field(body, b"Subject").or_else(|| extract_ews_field(body, b"Value"))
+        {
+            current_item.subject = v;
+        }
+        if let Some(v) =
+            extract_ews_field(body, b"Start").and_then(|v| crate::calendar::parse_datetime(&v))
+        {
+            current_item.start = v;
+        }
+        if let Some(v) =
+            extract_ews_field(body, b"End").and_then(|v| crate::calendar::parse_datetime(&v))
+        {
+            current_item.end = v;
+        }
+        if let Some(v) = extract_ews_field(body, b"Location") {
+            current_item.location = v;
+        }
+        if let Some(v) =
+            extract_ews_field(body, b"Body").or_else(|| extract_ews_field(body, b"TextBody"))
+        {
+            current_item.description = v;
+        }
+        if body.contains("Categories") {
+            current_item.categories = extract_ews_fields(body, b"String");
+        }
+        if let Some(v) =
+            extract_ews_field(body, b"ReminderMinutesBeforeStart").and_then(|v| v.parse().ok())
+        {
+            current_item.reminder = Some(v);
+        }
         if let Some(v) = extract_ews_field(body, b"LegacyFreeBusyStatus") {
-            current_item.busy_status = match v.as_str() { "Free" => Some(0), "Tentative" => Some(1), "Busy" => Some(2), "OOF" => Some(3), _ => current_item.busy_status };
+            current_item.busy_status = match v.as_str() {
+                "Free" => Some(0),
+                "Tentative" => Some(1),
+                "Busy" => Some(2),
+                "OOF" => Some(3),
+                _ => current_item.busy_status,
+            };
         }
         if let Some(v) = extract_ews_field(body, b"Sensitivity") {
-            current_item.sensitivity = match v.as_str() { "Normal" => Some(0), "Personal" => Some(1), "Private" => Some(2), "Confidential" => Some(3), _ => current_item.sensitivity };
+            current_item.sensitivity = match v.as_str() {
+                "Normal" => Some(0),
+                "Personal" => Some(1),
+                "Private" => Some(2),
+                "Confidential" => Some(3),
+                _ => current_item.sensitivity,
+            };
         }
-        if let Some(v) = extract_ews_field(body, b"ResponseRequested") { current_item.response_requested = Some(v.eq_ignore_ascii_case("true")); }
-        if let Some(v) = extract_ews_field(body, b"DisallowNewTimeProposal") { current_item.disallow_new_time_proposal = Some(v.eq_ignore_ascii_case("true")); }
-        if let Some(v) = extract_ews_field(body, b"OrganizerName") { current_item.organizer_name = Some(v); }
-        if let Some(v) = extract_ews_field(body, b"OrganizerEmail") { current_item.organizer_email = Some(v); }
-        if body.contains("RequiredAttendees") || body.contains("OptionalAttendees") { current_item.attendees = parse_ews_attendees(body); }
-        if body.contains("Recurrence") { current_item.rrule = parse_ews_recurrence(body); }
-        if let Some(v) = extract_ews_field(body, b"StartTimeZone") { current_item.timezone = Some(v); }
-        if let Some(v) = extract_ews_field(body, b"MeetingTimeZone") { current_item.timezone_blob = Some(v); }
-        if let Some(v) = extract_ews_field(body, b"OnlineMeetingConfLink") { current_item.online_meeting_conf_link = Some(v); }
-        if let Some(v) = extract_ews_field(body, b"OnlineMeetingExternalLink") { current_item.online_meeting_external_link = Some(v); }
-        if let Some(v) = extract_ews_field(body, b"ClientUid") { current_item.client_uid = Some(v); }
+        if let Some(v) = extract_ews_field(body, b"ResponseRequested") {
+            current_item.response_requested = Some(v.eq_ignore_ascii_case("true"));
+        }
+        if let Some(v) = extract_ews_field(body, b"DisallowNewTimeProposal") {
+            current_item.disallow_new_time_proposal = Some(v.eq_ignore_ascii_case("true"));
+        }
+        if let Some(v) = extract_ews_field(body, b"OrganizerName") {
+            current_item.organizer_name = Some(v);
+        }
+        if let Some(v) = extract_ews_field(body, b"OrganizerEmail") {
+            current_item.organizer_email = Some(v);
+        }
+        if body.contains("RequiredAttendees") || body.contains("OptionalAttendees") {
+            current_item.attendees = parse_ews_attendees(body);
+        }
+        if body.contains("Recurrence") {
+            current_item.rrule = parse_ews_recurrence(body);
+        }
+        if let Some(v) = extract_ews_field(body, b"StartTimeZone") {
+            current_item.timezone = Some(v);
+        }
+        if let Some(v) = extract_ews_field(body, b"MeetingTimeZone") {
+            current_item.timezone_blob = Some(v);
+        }
+        if let Some(v) = extract_ews_field(body, b"OnlineMeetingConfLink") {
+            current_item.online_meeting_conf_link = Some(v);
+        }
+        if let Some(v) = extract_ews_field(body, b"OnlineMeetingExternalLink") {
+            current_item.online_meeting_external_link = Some(v);
+        }
+        if let Some(v) = extract_ews_field(body, b"ClientUid") {
+            current_item.client_uid = Some(v);
+        }
     }
     let uid = current_item.uid.clone();
     let ics = render_ics(&current_item);
-    let (resource_href, new_etag) = match caldav.put_event(&stored_item.resource_href, Some(&stored_item.resource_href), &ics, owner, &auth.password,
-        existing_etag.as_deref().or(stored_item.etag.as_deref())).await
+    let (resource_href, new_etag) = match caldav
+        .put_event(
+            &stored_item.resource_href,
+            Some(&stored_item.resource_href),
+            &ics,
+            owner,
+            &auth.password,
+            existing_etag.as_deref().or(stored_item.etag.as_deref()),
+        )
+        .await
     {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::UpdateItem, "ErrorInternalServerError", &format!("Failed to persist update: {e}"), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::UpdateItem,
+                "ErrorInternalServerError",
+                &format!("Failed to persist update: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    if let Err(e) = state.storage.upsert_item_map(owner, &resource_href, &resource_href, &stored_item.server_id, &uid, &new_etag).await {
-        return operation_error_response(&EwsAction::UpdateItem, "ErrorInternalServerError", &format!("Failed to persist update mapping: {}", e), StatusCode::INTERNAL_SERVER_ERROR);
+    if let Err(e) = state
+        .storage
+        .upsert_item_map(
+            owner,
+            &resource_href,
+            &resource_href,
+            &stored_item.server_id,
+            &uid,
+            &new_etag,
+        )
+        .await
+    {
+        return operation_error_response(
+            &EwsAction::UpdateItem,
+            "ErrorInternalServerError",
+            &format!("Failed to persist update mapping: {}", e),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
     }
-    let response_row = EwsItemRow { server_id: stored_item.server_id.clone(), resource_href, uid: Some(uid), etag: Some(new_etag), updated_at: None };
+    let response_row = EwsItemRow {
+        server_id: stored_item.server_id.clone(),
+        resource_href,
+        uid: Some(uid),
+        etag: Some(new_etag),
+        updated_at: None,
+    };
     let response = format!(
         r#"<m:UpdateItemResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:UpdateItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items>{}</m:Items></m:UpdateItemResponseMessage></m:ResponseMessages></m:UpdateItemResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, render_ews_calendar_item_xml(&stored_item.server_id, &changekey_for_item(&response_row), &current_item)
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        render_ews_calendar_item_xml(
+            &stored_item.server_id,
+            &changekey_for_item(&response_row),
+            &current_item
+        )
     );
     soap_ok(response)
 }
@@ -1220,25 +2324,86 @@ async fn handle_update_item(state: &Arc<AppState>, auth: &AuthContext, body: &st
 async fn handle_delete_item(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
     let owner = owner_from_username(&auth.username);
     let item_id = extract_first_attr(body, b"ItemId", b"Id").unwrap_or_default();
-    if item_id.is_empty() { return operation_error_response(&EwsAction::DeleteItem, "ErrorInvalidIdMalformed", "DeleteItem requires ItemId/@Id", StatusCode::OK); }
-    let existing = match state.storage.get_ews_item_by_server_id(owner, &item_id).await {
+    if item_id.is_empty() {
+        return operation_error_response(
+            &EwsAction::DeleteItem,
+            "ErrorInvalidIdMalformed",
+            "DeleteItem requires ItemId/@Id",
+            StatusCode::OK,
+        );
+    }
+    let existing = match state
+        .storage
+        .get_ews_item_by_server_id(owner, &item_id)
+        .await
+    {
         Ok(v) => v,
-        Err(e) => return operation_error_response(&EwsAction::DeleteItem, "ErrorInternalServerError", &format!("Failed to resolve item: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::DeleteItem,
+                "ErrorInternalServerError",
+                &format!("Failed to resolve item: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    let Some(existing) = existing else { return operation_error_response(&EwsAction::DeleteItem, "ErrorItemNotFound", "Requested item does not exist", StatusCode::OK); };
-    if let Err(resp) = validate_item_change_key(&EwsAction::DeleteItem, body, &existing) { return resp; }
+    let Some(existing) = existing else {
+        return operation_error_response(
+            &EwsAction::DeleteItem,
+            "ErrorItemNotFound",
+            "Requested item does not exist",
+            StatusCode::OK,
+        );
+    };
+    if let Err(resp) = validate_item_change_key(&EwsAction::DeleteItem, body, &existing) {
+        return resp;
+    }
     let caldav = match CaldavClient::new(&state.cfg) {
         Ok(c) => c,
-        Err(e) => return operation_error_response(&EwsAction::GetItem, "ErrorInternalServerError", &format!("Failed to create CalDAV client: {}", e), StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            return operation_error_response(
+                &EwsAction::GetItem,
+                "ErrorInternalServerError",
+                &format!("Failed to create CalDAV client: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
     };
-    if let Err(e) = caldav.delete_event(&existing.resource_href, owner, &auth.password, existing.etag.as_deref()).await {
-        return operation_error_response(&EwsAction::DeleteItem, "ErrorInternalServerError", &format!("Failed to delete CalDAV item: {}", e), StatusCode::INTERNAL_SERVER_ERROR);
+    if let Err(e) = caldav
+        .delete_event(
+            &existing.resource_href,
+            owner,
+            &auth.password,
+            existing.etag.as_deref(),
+        )
+        .await
+    {
+        return operation_error_response(
+            &EwsAction::DeleteItem,
+            "ErrorInternalServerError",
+            &format!("Failed to delete CalDAV item: {}", e),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
     }
     if let Err(e) = state.storage.add_delete_tombstone(owner, &item_id).await {
-        return operation_error_response(&EwsAction::DeleteItem, "ErrorInternalServerError", &format!("Failed to persist delete tombstone: {}", e), StatusCode::INTERNAL_SERVER_ERROR);
+        return operation_error_response(
+            &EwsAction::DeleteItem,
+            "ErrorInternalServerError",
+            &format!("Failed to persist delete tombstone: {}", e),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
     }
-    if let Err(e) = state.storage.delete_item_by_server_id(owner, &item_id).await {
-        return operation_error_response(&EwsAction::DeleteItem, "ErrorInternalServerError", &format!("Failed to delete mapping: {}", e), StatusCode::INTERNAL_SERVER_ERROR);
+    if let Err(e) = state
+        .storage
+        .delete_item_by_server_id(owner, &item_id)
+        .await
+    {
+        return operation_error_response(
+            &EwsAction::DeleteItem,
+            "ErrorInternalServerError",
+            &format!("Failed to delete mapping: {}", e),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
     }
     let response = format!(
         r#"<m:DeleteItemResponse xmlns:m="{}"><m:ResponseMessages><m:DeleteItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:DeleteItemResponseMessage></m:ResponseMessages></m:DeleteItemResponse>"#,
@@ -1248,40 +2413,75 @@ async fn handle_delete_item(state: &Arc<AppState>, auth: &AuthContext, body: &st
 }
 
 async fn handle_resolve_names(auth: &AuthContext, body: &str) -> Response {
-    let unresolved = extract_first_tag_text(body, b"UnresolvedEntry").unwrap_or_else(|| auth.username.clone());
-    let mailbox = if unresolved.contains('@') { unresolved } else { auth.username.clone() };
+    let unresolved =
+        extract_first_tag_text(body, b"UnresolvedEntry").unwrap_or_else(|| auth.username.clone());
+    let mailbox = if unresolved.contains('@') {
+        unresolved
+    } else {
+        auth.username.clone()
+    };
     let response = format!(
         r#"<m:ResolveNamesResponse xmlns:m="{}" xmlns:t="{}"><m:ResponseMessages><m:ResolveNamesResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:ResolutionSet TotalItemsInView="1" IncludesLastItemInRange="true"><t:Resolution><t:Mailbox><t:Name>{}</t:Name><t:EmailAddress>{}</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType><t:MailboxType>Mailbox</t:MailboxType></t:Mailbox></t:Resolution></m:ResolutionSet></m:ResolveNamesResponseMessage></m:ResponseMessages></m:ResolveNamesResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, xml_escape(&mailbox), xml_escape(&mailbox)
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        xml_escape(&mailbox),
+        xml_escape(&mailbox)
     );
     soap_ok(response)
 }
 
-async fn handle_get_user_availability(state: &Arc<AppState>, auth: &AuthContext, body: &str) -> Response {
+async fn handle_get_user_availability(
+    state: &Arc<AppState>,
+    auth: &AuthContext,
+    body: &str,
+) -> Response {
     let mailboxes = {
-        let parsed = extract_tag_texts(body, b"EmailAddress").into_iter().filter(|v| !v.is_empty()).collect::<Vec<_>>();
-        if parsed.is_empty() { vec![auth.username.clone()] } else { parsed }
+        let parsed = extract_tag_texts(body, b"EmailAddress")
+            .into_iter()
+            .filter(|v| !v.is_empty())
+            .collect::<Vec<_>>();
+        if parsed.is_empty() {
+            vec![auth.username.clone()]
+        } else {
+            parsed
+        }
     };
-    let start = extract_first_tag_text(body, b"StartTime").and_then(|v| crate::calendar::parse_datetime(&v)).unwrap_or_else(chrono::Utc::now);
-    let end = extract_first_tag_text(body, b"EndTime").and_then(|v| crate::calendar::parse_datetime(&v)).unwrap_or_else(|| start + chrono::Duration::days(7));
-    let interval = extract_first_tag_text(body, b"MergedFreeBusyIntervalInMinutes").and_then(|v| v.parse::<i64>().ok()).unwrap_or(30);
-    let suggestion_minutes = extract_first_tag_text(body, b"MeetingDurationInMinutes").and_then(|v| v.parse::<i64>().ok()).unwrap_or(interval);
+    let start = extract_first_tag_text(body, b"StartTime")
+        .and_then(|v| crate::calendar::parse_datetime(&v))
+        .unwrap_or_else(chrono::Utc::now);
+    let end = extract_first_tag_text(body, b"EndTime")
+        .and_then(|v| crate::calendar::parse_datetime(&v))
+        .unwrap_or_else(|| start + chrono::Duration::days(7));
+    let interval = extract_first_tag_text(body, b"MergedFreeBusyIntervalInMinutes")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(30);
+    let suggestion_minutes = extract_first_tag_text(body, b"MeetingDurationInMinutes")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(interval);
     let view_type = requested_freebusy_view_type(body);
     let mut combined_merged = String::new();
     let mut responses = String::new();
     for mailbox in &mailboxes {
-        let (merged, events_xml) = merged_freebusy_for_mailbox(state, mailbox, &auth.password, start, end, interval).await;
-        combined_merged = if combined_merged.is_empty() { merged.clone() } else { merge_merged_freebusy(&combined_merged, &merged) };
+        let (merged, events_xml) =
+            merged_freebusy_for_mailbox(state, mailbox, &auth.password, start, end, interval).await;
+        combined_merged = if combined_merged.is_empty() {
+            merged.clone()
+        } else {
+            merge_merged_freebusy(&combined_merged, &merged)
+        };
         responses.push_str(&format!(
             r#"<m:FreeBusyResponse><m:ResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:ResponseMessage><m:FreeBusyView><t:FreeBusyViewType>{view_type}</t:FreeBusyViewType><t:MergedFreeBusy>{merged}</t:MergedFreeBusy><t:CalendarEventArray>{events_xml}</t:CalendarEventArray></m:FreeBusyView></m:FreeBusyResponse>"#,
         ));
     }
     let suggestions_xml = if body.contains("SuggestionsViewOptions") {
         suggestions_xml_for_window(&combined_merged, start, end, interval, suggestion_minutes)
-    } else { String::new() };
+    } else {
+        String::new()
+    };
     let response = format!(
         r#"<m:GetUserAvailabilityResponse xmlns:m="{msg_ns}" xmlns:t="{type_ns}"><m:FreeBusyResponseArray>{responses}</m:FreeBusyResponseArray>{suggestions_xml}</m:GetUserAvailabilityResponse>"#,
-        msg_ns = EWS_MSG_NS, type_ns = EWS_TYPE_NS
+        msg_ns = EWS_MSG_NS,
+        type_ns = EWS_TYPE_NS
     );
     soap_ok(response)
 }
@@ -1377,7 +2577,9 @@ async fn handle_get_mail_tips(auth: &AuthContext, _body: &str) -> Response {
     </m:MailTipsResponseMessage>
   </m:ResponseMessages>
 </m:GetMailTipsResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, xml_escape(&auth.username)
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        xml_escape(&auth.username)
     );
     soap_ok(inner)
 }
@@ -1399,7 +2601,8 @@ async fn handle_find_people(auth: &AuthContext, _body: &str) -> Response {
     </m:FindPeopleResponseMessage>
   </m:ResponseMessages>
 </m:FindPeopleResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS,
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
         uuid::Uuid::new_v4(),
         xml_escape(&auth.username),
         xml_escape(&auth.username),
@@ -1431,7 +2634,10 @@ async fn handle_convert_id(auth: &AuthContext, _body: &str) -> Response {
 </m:ConvertIdResponseMessage>
 </m:ResponseMessages>
 </m:ConvertIdResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS, xml_escape(&auth.username), xml_escape(&auth.username)
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
+        xml_escape(&auth.username),
+        xml_escape(&auth.username)
     );
     soap_ok(inner)
 }
@@ -1626,7 +2832,8 @@ async fn handle_get_persona(auth: &AuthContext, _body: &str) -> Response {
     </m:GetPersonaResponseMessage>
   </m:ResponseMessages>
 </m:GetPersonaResponse>"#,
-        EWS_MSG_NS, EWS_TYPE_NS,
+        EWS_MSG_NS,
+        EWS_TYPE_NS,
         uuid::Uuid::new_v4(),
         xml_escape(&auth.username),
         xml_escape(&auth.username)

--- a/src/ews_folders.rs
+++ b/src/ews_folders.rs
@@ -127,11 +127,7 @@ pub fn folder_id_for(owner: &str, folder: DistinguishedFolder) -> String {
     )
 }
 
-pub fn render_folder_xml(
-    owner: &str,
-    folder: DistinguishedFolder,
-    total_count: usize,
-) -> String {
+pub fn render_folder_xml(owner: &str, folder: DistinguishedFolder, total_count: usize) -> String {
     let fid = folder_id_for(owner, folder);
     let parent = folder_id_for(owner, DistinguishedFolder::MsgFolderRoot);
     let prefix_len = fid.find('-').map(|i| i + 1).unwrap_or(4);
@@ -202,10 +198,10 @@ pub fn validate_folder_request(
         }
     }
 
-    if let Some(did) = distinguished_id {
-        if DistinguishedFolder::from_str(did).is_none() {
-            return Some("ErrorFolderNotFound");
-        }
+    if let Some(did) = distinguished_id
+        && DistinguishedFolder::from_str(did).is_none()
+    {
+        return Some("ErrorFolderNotFound");
     }
     None
 }
@@ -224,11 +220,23 @@ mod tests {
     #[test]
     fn all_distinguished_folders_parse() {
         let ids = [
-            "calendar", "msgfolderroot", "inbox", "sentitems", "deleteditems",
-            "drafts", "outbox", "junkemail", "contacts", "tasks", "notes",
+            "calendar",
+            "msgfolderroot",
+            "inbox",
+            "sentitems",
+            "deleteditems",
+            "drafts",
+            "outbox",
+            "junkemail",
+            "contacts",
+            "tasks",
+            "notes",
         ];
         for id in &ids {
-            assert!(DistinguishedFolder::from_str(id).is_some(), "Failed to parse: {id}");
+            assert!(
+                DistinguishedFolder::from_str(id).is_some(),
+                "Failed to parse: {id}"
+            );
         }
     }
 
@@ -271,7 +279,8 @@ mod tests {
 
     #[test]
     fn validate_unknown_distinguished_id_fails() {
-        let result = validate_folder_request("user@example.com", Some("publicfoldersroot"), None, None);
+        let result =
+            validate_folder_request("user@example.com", Some("publicfoldersroot"), None, None);
         assert_eq!(result, Some("ErrorFolderNotFound"));
     }
 

--- a/src/ews_update.rs
+++ b/src/ews_update.rs
@@ -1,10 +1,9 @@
 // src/ews_update.rs
 use crate::calendar::{
-    extract_ews_field, extract_ews_fields, parse_ews_attendees, parse_ews_recurrence,
-    CalendarItem,
+    CalendarItem, extract_ews_field, extract_ews_fields, parse_ews_attendees, parse_ews_recurrence,
 };
-use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
+use quick_xml::events::{BytesEnd, BytesStart, Event};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EwsFieldChange {
@@ -71,7 +70,9 @@ fn push_start_tag(out: &mut String, e: &BytesStart<'_>) {
         out.push_str("=\"");
         match attr.unescape_value() {
             Ok(value) => out.push_str(&xml_escape_attr(&value)),
-            Err(_) => out.push_str(&xml_escape_attr(&String::from_utf8_lossy(attr.value.as_ref()))),
+            Err(_) => out.push_str(&xml_escape_attr(&String::from_utf8_lossy(
+                attr.value.as_ref(),
+            ))),
         }
         out.push('"');
     }
@@ -87,7 +88,9 @@ fn push_empty_tag(out: &mut String, e: &BytesStart<'_>) {
         out.push_str("=\"");
         match attr.unescape_value() {
             Ok(value) => out.push_str(&xml_escape_attr(&value)),
-            Err(_) => out.push_str(&xml_escape_attr(&String::from_utf8_lossy(attr.value.as_ref()))),
+            Err(_) => out.push_str(&xml_escape_attr(&String::from_utf8_lossy(
+                attr.value.as_ref(),
+            ))),
         }
         out.push('"');
     }
@@ -101,7 +104,9 @@ fn push_end_tag(out: &mut String, e: &BytesEnd<'_>) {
 }
 
 fn first_ews_field(payload: &str, candidates: &[&[u8]]) -> Option<String> {
-    candidates.iter().find_map(|name| extract_ews_field(payload, name))
+    candidates
+        .iter()
+        .find_map(|name| extract_ews_field(payload, name))
 }
 
 fn first_ews_i32(payload: &str, candidates: &[&[u8]]) -> Option<i32> {
@@ -142,13 +147,18 @@ pub fn parse_item_changes(body: &str) -> Vec<EwsFieldChange> {
                             };
                         }
                     }
-                    State::InVerb { field_uri, payload_xml, collecting_payload, .. } => {
+                    State::InVerb {
+                        field_uri,
+                        payload_xml,
+                        collecting_payload,
+                        ..
+                    } => {
                         if local == "FieldURI" && field_uri.is_none() {
                             for attr in e.attributes().flatten() {
-                                if attr.key.local_name().as_ref() == b"FieldURI" {
-                                    if let Ok(v) = attr.unescape_value() {
-                                        *field_uri = Some(v.to_string());
-                                    }
+                                if attr.key.local_name().as_ref() == b"FieldURI"
+                                    && let Ok(v) = attr.unescape_value()
+                                {
+                                    *field_uri = Some(v.to_string());
                                 }
                             }
                         } else if field_uri.is_some() {
@@ -162,13 +172,18 @@ pub fn parse_item_changes(body: &str) -> Vec<EwsFieldChange> {
                 let local = local_name_bytes(e.name().as_ref());
                 match &mut state {
                     State::Root => {}
-                    State::InVerb { field_uri, payload_xml, collecting_payload, .. } => {
+                    State::InVerb {
+                        field_uri,
+                        payload_xml,
+                        collecting_payload,
+                        ..
+                    } => {
                         if local == "FieldURI" && field_uri.is_none() {
                             for attr in e.attributes().flatten() {
-                                if attr.key.local_name().as_ref() == b"FieldURI" {
-                                    if let Ok(v) = attr.unescape_value() {
-                                        *field_uri = Some(v.to_string());
-                                    }
+                                if attr.key.local_name().as_ref() == b"FieldURI"
+                                    && let Ok(v) = attr.unescape_value()
+                                {
+                                    *field_uri = Some(v.to_string());
                                 }
                             }
                         } else if field_uri.is_some() {
@@ -182,8 +197,16 @@ pub fn parse_item_changes(body: &str) -> Vec<EwsFieldChange> {
                 let local = local_name_bytes(e.name().as_ref());
                 match &mut state {
                     State::Root => {}
-                    State::InVerb { verb, field_uri, payload_xml, collecting_payload } => {
-                        if matches!(local.as_str(), "SetItemField" | "AppendToItemField" | "DeleteItemField") {
+                    State::InVerb {
+                        verb,
+                        field_uri,
+                        payload_xml,
+                        collecting_payload,
+                    } => {
+                        if matches!(
+                            local.as_str(),
+                            "SetItemField" | "AppendToItemField" | "DeleteItemField"
+                        ) {
                             if let Some(field_uri) = field_uri.take() {
                                 results.push(EwsFieldChange {
                                     verb: *verb,
@@ -199,17 +222,25 @@ pub fn parse_item_changes(body: &str) -> Vec<EwsFieldChange> {
                 }
             }
             Ok(Event::Text(t)) => {
-                if let State::InVerb { collecting_payload: true, payload_xml, .. } = &mut state {
-                    if let Ok(text) = t.decode() {
-                        payload_xml.push_str(&xml_escape_text(&text));
-                    }
+                if let State::InVerb {
+                    collecting_payload: true,
+                    payload_xml,
+                    ..
+                } = &mut state
+                    && let Ok(text) = t.decode()
+                {
+                    payload_xml.push_str(&xml_escape_text(&text));
                 }
             }
             Ok(Event::CData(t)) => {
-                if let State::InVerb { collecting_payload: true, payload_xml, .. } = &mut state {
-                    if let Ok(text) = t.decode() {
-                        payload_xml.push_str(&xml_escape_text(&text));
-                    }
+                if let State::InVerb {
+                    collecting_payload: true,
+                    payload_xml,
+                    ..
+                } = &mut state
+                    && let Ok(text) = t.decode()
+                {
+                    payload_xml.push_str(&xml_escape_text(&text));
                 }
             }
             Ok(Event::Eof) | Err(_) => break,
@@ -231,7 +262,9 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "item:subject" => match verb {
                 ChangeVerb::Delete => item.subject.clear(),
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"Subject".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) =
+                        first_ews_field(payload, &[b"Subject".as_ref(), b"Value".as_ref()])
+                    {
                         item.subject = v;
                     }
                 }
@@ -239,7 +272,10 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "item:body" => match verb {
                 ChangeVerb::Delete => item.description.clear(),
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"Body".as_ref(), b"TextBody".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) = first_ews_field(
+                        payload,
+                        &[b"Body".as_ref(), b"TextBody".as_ref(), b"Value".as_ref()],
+                    ) {
                         item.description = v;
                     }
                 }
@@ -247,17 +283,20 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "item:reminderisset" => match verb {
                 ChangeVerb::Delete => item.reminder = None,
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"ReminderIsSet".as_ref()]) {
-                        if v.eq_ignore_ascii_case("false") {
-                            item.reminder = None;
-                        }
+                    if let Some(v) = first_ews_field(payload, &[b"ReminderIsSet".as_ref()])
+                        && v.eq_ignore_ascii_case("false")
+                    {
+                        item.reminder = None;
                     }
                 }
             },
             "item:reminderminutesbeforestart" => match verb {
                 ChangeVerb::Delete => item.reminder = None,
                 _ => {
-                    if let Some(v) = first_ews_i32(payload, &[b"ReminderMinutesBeforeStart".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) = first_ews_i32(
+                        payload,
+                        &[b"ReminderMinutesBeforeStart".as_ref(), b"Value".as_ref()],
+                    ) {
                         item.reminder = Some(v);
                     }
                 }
@@ -265,7 +304,9 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "item:sensitivity" => match verb {
                 ChangeVerb::Delete => item.sensitivity = None,
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"Sensitivity".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) =
+                        first_ews_field(payload, &[b"Sensitivity".as_ref(), b"Value".as_ref()])
+                    {
                         item.sensitivity = Some(match v.as_str() {
                             "Normal" => 0,
                             "Personal" => 1,
@@ -287,8 +328,9 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "calendar:start" => match verb {
                 ChangeVerb::Delete => {}
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"Start".as_ref(), b"Value".as_ref()])
-                        .and_then(|s| crate::calendar::parse_datetime(&s))
+                    if let Some(v) =
+                        first_ews_field(payload, &[b"Start".as_ref(), b"Value".as_ref()])
+                            .and_then(|s| crate::calendar::parse_datetime(&s))
                     {
                         item.start = v;
                     }
@@ -315,7 +357,9 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "calendar:location" => match verb {
                 ChangeVerb::Delete => item.location.clear(),
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"Location".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) =
+                        first_ews_field(payload, &[b"Location".as_ref(), b"Value".as_ref()])
+                    {
                         item.location = v;
                     }
                 }
@@ -323,7 +367,10 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "calendar:legacyfreebusystatus" => match verb {
                 ChangeVerb::Delete => item.busy_status = None,
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"LegacyFreeBusyStatus".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) = first_ews_field(
+                        payload,
+                        &[b"LegacyFreeBusyStatus".as_ref(), b"Value".as_ref()],
+                    ) {
                         item.busy_status = Some(match v.as_str() {
                             "Free" => 0,
                             "Tentative" => 1,
@@ -336,7 +383,9 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             },
             "calendar:recurrence" => match verb {
                 ChangeVerb::Delete => item.rrule = None,
-                _ => { item.rrule = parse_ews_recurrence(payload); }
+                _ => {
+                    item.rrule = parse_ews_recurrence(payload);
+                }
             },
             "calendar:requiredattendees" | "calendar:optionalattendees" => {
                 let attendees = parse_ews_attendees(payload);
@@ -344,16 +393,26 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
                 match verb {
                     ChangeVerb::Delete => {
                         item.attendees.retain(|a| {
-                            if is_optional { a.attendee_type != Some(2) } else { a.attendee_type == Some(2) }
+                            if is_optional {
+                                a.attendee_type != Some(2)
+                            } else {
+                                a.attendee_type == Some(2)
+                            }
                         });
                     }
                     ChangeVerb::Set => {
                         item.attendees.retain(|a| {
-                            if is_optional { a.attendee_type != Some(2) } else { a.attendee_type == Some(2) }
+                            if is_optional {
+                                a.attendee_type != Some(2)
+                            } else {
+                                a.attendee_type == Some(2)
+                            }
                         });
                         item.attendees.extend(attendees);
                     }
-                    ChangeVerb::Append => { item.attendees.extend(attendees); }
+                    ChangeVerb::Append => {
+                        item.attendees.extend(attendees);
+                    }
                 }
             }
             "calendar:organizer" => match verb {
@@ -373,7 +432,13 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "calendar:isresponserequested" | "calendar:responserequested" => match verb {
                 ChangeVerb::Delete => item.response_requested = None,
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"IsResponseRequested".as_ref(), b"ResponseRequested".as_ref()]) {
+                    if let Some(v) = first_ews_field(
+                        payload,
+                        &[
+                            b"IsResponseRequested".as_ref(),
+                            b"ResponseRequested".as_ref(),
+                        ],
+                    ) {
                         item.response_requested = Some(v.eq_ignore_ascii_case("true"));
                     }
                 }
@@ -389,24 +454,28 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "calendar:starttimezone" | "calendar:starttimezoneid" => match verb {
                 ChangeVerb::Delete => item.timezone = None,
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"StartTimeZone".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) =
+                        first_ews_field(payload, &[b"StartTimeZone".as_ref(), b"Value".as_ref()])
+                    {
                         item.timezone = Some(v);
                     }
                 }
             },
             "calendar:endtimezone" | "calendar:endtimezoneid" => {
-                if verb != ChangeVerb::Delete {
-                    if let Some(v) = first_ews_field(payload, &[b"EndTimeZone".as_ref(), b"Value".as_ref()]) {
-                        if item.timezone.is_none() {
-                            item.timezone = Some(v);
-                        }
-                    }
+                if verb != ChangeVerb::Delete
+                    && let Some(v) =
+                        first_ews_field(payload, &[b"EndTimeZone".as_ref(), b"Value".as_ref()])
+                    && item.timezone.is_none()
+                {
+                    item.timezone = Some(v);
                 }
             }
             "calendar:meetingtimezone" => match verb {
                 ChangeVerb::Delete => item.timezone_blob = None,
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"MeetingTimeZone".as_ref(), b"Value".as_ref()]) {
+                    if let Some(v) =
+                        first_ews_field(payload, &[b"MeetingTimeZone".as_ref(), b"Value".as_ref()])
+                    {
                         item.timezone_blob = Some(v);
                     }
                 }
@@ -415,8 +484,11 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             "calendar:appointmentreplytime" => match verb {
                 ChangeVerb::Delete => item.appointment_reply_time = None,
                 _ => {
-                    if let Some(v) = first_ews_field(payload, &[b"AppointmentReplyTime".as_ref(), b"Value".as_ref()])
-                        .and_then(|s| crate::calendar::parse_datetime(&s))
+                    if let Some(v) = first_ews_field(
+                        payload,
+                        &[b"AppointmentReplyTime".as_ref(), b"Value".as_ref()],
+                    )
+                    .and_then(|s| crate::calendar::parse_datetime(&s))
                     {
                         item.appointment_reply_time = Some(v);
                     }
@@ -424,11 +496,21 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
             },
             "calendar:onlinemeetingconflink" => match verb {
                 ChangeVerb::Delete => item.online_meeting_conf_link = None,
-                _ => { item.online_meeting_conf_link = first_ews_field(payload, &[b"OnlineMeetingConfLink".as_ref(), b"Value".as_ref()]); }
+                _ => {
+                    item.online_meeting_conf_link = first_ews_field(
+                        payload,
+                        &[b"OnlineMeetingConfLink".as_ref(), b"Value".as_ref()],
+                    );
+                }
             },
             "calendar:onlinemeetingexternallink" => match verb {
                 ChangeVerb::Delete => item.online_meeting_external_link = None,
-                _ => { item.online_meeting_external_link = first_ews_field(payload, &[b"OnlineMeetingExternalLink".as_ref(), b"Value".as_ref()]); }
+                _ => {
+                    item.online_meeting_external_link = first_ews_field(
+                        payload,
+                        &[b"OnlineMeetingExternalLink".as_ref(), b"Value".as_ref()],
+                    );
+                }
             },
             _ => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,20 +4,18 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{
+    Router,
     extract::{Query, State},
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
     routing::{any, get, post},
-    Router,
 };
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_http::{
-    sensitive_headers::SetSensitiveRequestHeadersLayer,
+    compression::CompressionLayer, limit::RequestBodyLimitLayer,
+    sensitive_headers::SetSensitiveRequestHeadersLayer, timeout::RequestBodyTimeoutLayer,
     trace::TraceLayer,
-    timeout::RequestBodyTimeoutLayer,
-    limit::RequestBodyLimitLayer,
-    compression::CompressionLayer,
 };
 use tracing_subscriber::EnvFilter;
 
@@ -69,7 +67,11 @@ async fn autodiscover_json(
     build_response(status, &hdrs, body_out)
 }
 
-fn build_response(status: StatusCode, hdrs: &[(&'static str, &'static str)], body: String) -> Response {
+fn build_response(
+    status: StatusCode,
+    hdrs: &[(&'static str, &'static str)],
+    body: String,
+) -> Response {
     let mut resp = (status, body).into_response();
     for (k, v) in hdrs {
         if let (Ok(name), Ok(value)) = (
@@ -94,7 +96,10 @@ async fn main() -> anyhow::Result<()> {
     let config = match Config::load(&config_path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("CRITICAL: Failed to load config from {}: {}", config_path, e);
+            eprintln!(
+                "CRITICAL: Failed to load config from {}: {}",
+                config_path, e
+            );
             return Err(e);
         }
     };
@@ -130,9 +135,11 @@ async fn main() -> anyhow::Result<()> {
                     header::HeaderName::from_static("x-gateway-secret"),
                 ]))
                 .layer(TraceLayer::new_for_http())
-                .layer(RequestBodyTimeoutLayer::new(Duration::from_secs(REQUEST_TIMEOUT_SECS)))
+                .layer(RequestBodyTimeoutLayer::new(Duration::from_secs(
+                    REQUEST_TIMEOUT_SECS,
+                )))
                 .layer(RequestBodyLimitLayer::new(MAX_BODY_BYTES))
-                .layer(CompressionLayer::new())
+                .layer(CompressionLayer::new()),
         )
         .with_state(app_state);
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,7 +1,7 @@
 // src/storage.rs
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
-use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use reqwest_tracing::TracingMiddleware;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -103,7 +103,7 @@ impl Storage {
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(Duration::from_millis(50), Duration::from_secs(3))
             .build_with_max_retries(3);
-        
+
         let client = ClientBuilder::new(
             reqwest::Client::builder()
                 .timeout(Duration::from_secs(15))
@@ -114,7 +114,7 @@ impl Storage {
         .with(TracingMiddleware::default())
         .with(RetryTransientMiddleware::new_with_policy(retry_policy))
         .build();
-        
+
         Ok(Self {
             client,
             base_url: worker_url.trim_end_matches('/').to_string(),
@@ -173,7 +173,12 @@ impl Storage {
         sync_key: &str,
         token: Option<&str>,
     ) -> Result<()> {
-        let body = SetSyncKeyReq { owner, collection_id, sync_key, token };
+        let body = SetSyncKeyReq {
+            owner,
+            collection_id,
+            sync_key,
+            token,
+        };
         self.post_json("set_sync_key", &body).await
     }
 
@@ -200,7 +205,14 @@ impl Storage {
         uid: &str,
         etag: &str,
     ) -> Result<()> {
-        let body = UpsertItemReq { owner, caldav_href, resource_href, server_id, uid, etag };
+        let body = UpsertItemReq {
+            owner,
+            caldav_href,
+            resource_href,
+            server_id,
+            uid,
+            etag,
+        };
         self.post_json("upsert_item_map", &body).await
     }
 
@@ -238,7 +250,13 @@ impl Storage {
         }
         self.post_json(
             "put_client_sync_command",
-            &Req { owner, collection_id, client_id, server_id, status },
+            &Req {
+                owner,
+                collection_id,
+                client_id,
+                server_id,
+                status,
+            },
         )
         .await
     }
@@ -249,7 +267,8 @@ impl Storage {
             owner: &'a str,
             server_id: &'a str,
         }
-        self.post_json("delete_item_by_server_id", &Req { owner, server_id }).await
+        self.post_json("delete_item_by_server_id", &Req { owner, server_id })
+            .await
     }
 
     pub async fn add_delete_tombstone(&self, owner: &str, server_id: &str) -> Result<()> {
@@ -258,7 +277,8 @@ impl Storage {
             owner: &'a str,
             server_id: &'a str,
         }
-        self.post_json("add_delete_tombstone", &Req { owner, server_id }).await
+        self.post_json("add_delete_tombstone", &Req { owner, server_id })
+            .await
     }
 
     pub async fn list_changes_since(
@@ -278,11 +298,7 @@ impl Storage {
             .collect())
     }
 
-    pub async fn list_deleted_since(
-        &self,
-        owner: &str,
-        since_unix_ts: i64,
-    ) -> Result<Vec<String>> {
+    pub async fn list_deleted_since(&self, owner: &str, since_unix_ts: i64) -> Result<Vec<String>> {
         let path = format!(
             "list_deleted_since?owner={}&since={}",
             urlencoding::encode(owner),
@@ -355,7 +371,12 @@ impl Storage {
         policy_key: &str,
         policy_status: &str,
     ) -> Result<()> {
-        let body = SetProvisionReq { owner, device_id, policy_key, policy_status };
+        let body = SetProvisionReq {
+            owner,
+            device_id,
+            policy_key,
+            policy_status,
+        };
         self.post_json("set_provision_policy", &body).await
     }
 
@@ -397,7 +418,16 @@ impl Storage {
         }
         self.post_json(
             "upsert_device_info",
-            &Req { owner, device_id, friendly_name, model, os, phone_number, imei, user_agent },
+            &Req {
+                owner,
+                device_id,
+                friendly_name,
+                model,
+                os,
+                phone_number,
+                imei,
+                user_agent,
+            },
         )
         .await
     }
@@ -452,7 +482,14 @@ impl Storage {
             folder_id: &'a str,
             sync_state: &'a str,
         }
-        self.post_json("set_ews_sync_state", &Req { owner, folder_id, sync_state })
-            .await
+        self.post_json(
+            "set_ews_sync_state",
+            &Req {
+                owner,
+                folder_id,
+                sync_state,
+            },
+        )
+        .await
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,16 +1,16 @@
 // src/sync.rs
 use crate::caldav::CaldavClient;
 use crate::calendar::{
-    parse_eas_sync_mutations, parse_ics_event, render_ics, Attendee, CalendarException,
-    CalendarItem, EasSyncMutation,
+    Attendee, CalendarException, CalendarItem, EasSyncMutation, parse_eas_sync_mutations,
+    parse_ics_event, render_ics,
 };
 use crate::models::AppState;
-use anyhow::{anyhow, Result};
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use anyhow::{Result, anyhow};
 use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{Duration, TimeZone, Utc};
-use hmac::{Hmac, Mac};
 use hmac::digest::KeyInit;
+use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -24,9 +24,19 @@ const MAX_WINDOW_SIZE: usize = 512;
 
 #[derive(Clone, Debug)]
 pub enum ClientMutationResult {
-    Add { client_id: Option<String>, server_id: Option<String>, status: &'static str },
-    Change { server_id: String, status: &'static str },
-    Delete { server_id: String, status: &'static str },
+    Add {
+        client_id: Option<String>,
+        server_id: Option<String>,
+        status: &'static str,
+    },
+    Change {
+        server_id: String,
+        status: &'static str,
+    },
+    Delete {
+        server_id: String,
+        status: &'static str,
+    },
 }
 
 pub fn generate_server_id(secret: &str, resource_href: &str) -> String {
@@ -40,7 +50,10 @@ fn sync_seq_to_token(seq: i64) -> String {
 }
 
 fn sync_since_from_token(token: Option<&str>) -> i64 {
-    token.and_then(|raw| raw.strip_prefix("seq:")).and_then(|v| v.parse::<i64>().ok()).unwrap_or(0)
+    token
+        .and_then(|raw| raw.strip_prefix("seq:"))
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0)
 }
 
 pub fn filter_type_to_start(filter_type: u8) -> chrono::DateTime<Utc> {
@@ -86,18 +99,26 @@ pub async fn apply_client_sync_mutations(
     xml: &str,
 ) -> Result<Vec<ClientMutationResult>> {
     let mutations = parse_eas_sync_mutations(xml)?;
-    if mutations.is_empty() { return Ok(Vec::new()); }
+    if mutations.is_empty() {
+        return Ok(Vec::new());
+    }
 
     let caldav = CaldavClient::new(&state.cfg)?;
     let calendars = caldav.find_user_calendars(username, password).await?;
-    let collection_href = calendars.first().ok_or_else(|| anyhow!("no calendars found"))?.clone();
+    let collection_href = calendars
+        .first()
+        .ok_or_else(|| anyhow!("no calendars found"))?
+        .clone();
     let mut results = Vec::new();
 
     for mutation in mutations {
         match mutation {
             EasSyncMutation::Add { client_id, item } => {
                 if let Some(client_id) = client_id.as_deref()
-                    && let Some((server_id, status)) = state.storage.get_client_sync_command(owner, collection_id, client_id).await?
+                    && let Some((server_id, status)) = state
+                        .storage
+                        .get_client_sync_command(owner, collection_id, client_id)
+                        .await?
                 {
                     results.push(ClientMutationResult::Add {
                         client_id: Some(client_id.to_string()),
@@ -108,84 +129,243 @@ pub async fn apply_client_sync_mutations(
                 }
                 let mut item = item;
                 if item.uid.is_empty() {
-                    item.uid = client_id.clone().unwrap_or_else(|| Uuid::new_v4().to_string());
+                    item.uid = client_id
+                        .clone()
+                        .unwrap_or_else(|| Uuid::new_v4().to_string());
                 }
                 let ics = render_ics(&item);
-                match caldav.put_event(&collection_href, None, &ics, username, password, None).await {
+                match caldav
+                    .put_event(&collection_href, None, &ics, username, password, None)
+                    .await
+                {
                     Ok((resource_href, etag)) => {
                         let server_id = generate_server_id(state.cfg.hmac_secret(), &resource_href);
-                        state.storage.upsert_item_map(owner, &collection_href, &resource_href, &server_id, &item.uid, &etag).await?;
+                        state
+                            .storage
+                            .upsert_item_map(
+                                owner,
+                                &collection_href,
+                                &resource_href,
+                                &server_id,
+                                &item.uid,
+                                &etag,
+                            )
+                            .await?;
                         if let Some(client_id) = client_id.as_deref() {
-                            state.storage.put_client_sync_command(owner, collection_id, client_id, Some(&server_id), "1").await?;
+                            state
+                                .storage
+                                .put_client_sync_command(
+                                    owner,
+                                    collection_id,
+                                    client_id,
+                                    Some(&server_id),
+                                    "1",
+                                )
+                                .await?;
                         }
-                        results.push(ClientMutationResult::Add { client_id, server_id: Some(server_id), status: "1" });
+                        results.push(ClientMutationResult::Add {
+                            client_id,
+                            server_id: Some(server_id),
+                            status: "1",
+                        });
                     }
                     Err(_) => {
                         if let Some(client_id) = client_id.as_deref() {
-                            let _ = state.storage.put_client_sync_command(owner, collection_id, client_id, None, "6").await;
+                            let _ = state
+                                .storage
+                                .put_client_sync_command(owner, collection_id, client_id, None, "6")
+                                .await;
                         }
-                        results.push(ClientMutationResult::Add { client_id, server_id: None, status: "6" });
+                        results.push(ClientMutationResult::Add {
+                            client_id,
+                            server_id: None,
+                            status: "6",
+                        });
                     }
                 }
             }
-            EasSyncMutation::Change { server_id, instance_id: _, patch } => {
-                let Some(existing) = state.storage.get_ews_item_by_server_id(owner, &server_id).await? else {
-                    results.push(ClientMutationResult::Change { server_id, status: "6" });
+            EasSyncMutation::Change {
+                server_id,
+                instance_id: _,
+                patch,
+            } => {
+                let Some(existing) = state
+                    .storage
+                    .get_ews_item_by_server_id(owner, &server_id)
+                    .await?
+                else {
+                    results.push(ClientMutationResult::Change {
+                        server_id,
+                        status: "6",
+                    });
                     continue;
                 };
-                let (existing_ics, existing_etag) = caldav.get_event(&existing.resource_href, username, password).await?;
-                let mut item = parse_ics_event(&existing_ics).ok_or_else(|| anyhow!("failed parsing existing calendar item"))?;
-                if let Some(v) = patch.uid { item.uid = v; }
-                if let Some(v) = patch.subject { item.subject = v; }
-                if let Some(v) = patch.description { item.description = v; }
-                if let Some(v) = patch.location { item.location = v; }
-                if let Some(v) = patch.start { item.start = v; }
-                if let Some(v) = patch.end { item.end = v; }
-                if let Some(v) = patch.all_day { item.all_day = v; }
-                if let Some(v) = patch.dtstamp { item.dtstamp = Some(v); }
-                if let Some(v) = patch.timezone { item.timezone = Some(v); }
-                if let Some(v) = patch.timezone_blob { item.timezone_blob = Some(v); }
-                if let Some(v) = patch.rrule { item.rrule = Some(v); }
-                if let Some(v) = patch.exdates { item.exdates = v; }
-                if let Some(v) = patch.organizer_name { item.organizer_name = Some(v); }
-                if let Some(v) = patch.organizer_email { item.organizer_email = Some(v); }
-                if let Some(v) = patch.attendees { item.attendees = v; }
-                if let Some(v) = patch.categories { item.categories = v; }
-                if let Some(v) = patch.busy_status { item.busy_status = Some(v); }
-                if let Some(v) = patch.sensitivity { item.sensitivity = Some(v); }
-                if let Some(v) = patch.reminder { item.reminder = Some(v); }
-                if let Some(v) = patch.response_requested { item.response_requested = Some(v); }
-                if let Some(v) = patch.disallow_new_time_proposal { item.disallow_new_time_proposal = Some(v); }
-                if let Some(v) = patch.appointment_reply_time { item.appointment_reply_time = Some(v); }
-                if let Some(v) = patch.meeting_status { item.meeting_status = Some(v); }
-                if let Some(v) = patch.response_type { item.response_type = Some(v); }
-                if let Some(v) = patch.online_meeting_conf_link { item.online_meeting_conf_link = Some(v); }
-                if let Some(v) = patch.online_meeting_external_link { item.online_meeting_external_link = Some(v); }
-                if let Some(v) = patch.client_uid { item.client_uid = Some(v); }
-                if let Some(v) = patch.exceptions { item.exceptions = v; }
+                let (existing_ics, existing_etag) = caldav
+                    .get_event(&existing.resource_href, username, password)
+                    .await?;
+                let mut item = parse_ics_event(&existing_ics)
+                    .ok_or_else(|| anyhow!("failed parsing existing calendar item"))?;
+                if let Some(v) = patch.uid {
+                    item.uid = v;
+                }
+                if let Some(v) = patch.subject {
+                    item.subject = v;
+                }
+                if let Some(v) = patch.description {
+                    item.description = v;
+                }
+                if let Some(v) = patch.location {
+                    item.location = v;
+                }
+                if let Some(v) = patch.start {
+                    item.start = v;
+                }
+                if let Some(v) = patch.end {
+                    item.end = v;
+                }
+                if let Some(v) = patch.all_day {
+                    item.all_day = v;
+                }
+                if let Some(v) = patch.dtstamp {
+                    item.dtstamp = Some(v);
+                }
+                if let Some(v) = patch.timezone {
+                    item.timezone = Some(v);
+                }
+                if let Some(v) = patch.timezone_blob {
+                    item.timezone_blob = Some(v);
+                }
+                if let Some(v) = patch.rrule {
+                    item.rrule = Some(v);
+                }
+                if let Some(v) = patch.exdates {
+                    item.exdates = v;
+                }
+                if let Some(v) = patch.organizer_name {
+                    item.organizer_name = Some(v);
+                }
+                if let Some(v) = patch.organizer_email {
+                    item.organizer_email = Some(v);
+                }
+                if let Some(v) = patch.attendees {
+                    item.attendees = v;
+                }
+                if let Some(v) = patch.categories {
+                    item.categories = v;
+                }
+                if let Some(v) = patch.busy_status {
+                    item.busy_status = Some(v);
+                }
+                if let Some(v) = patch.sensitivity {
+                    item.sensitivity = Some(v);
+                }
+                if let Some(v) = patch.reminder {
+                    item.reminder = Some(v);
+                }
+                if let Some(v) = patch.response_requested {
+                    item.response_requested = Some(v);
+                }
+                if let Some(v) = patch.disallow_new_time_proposal {
+                    item.disallow_new_time_proposal = Some(v);
+                }
+                if let Some(v) = patch.appointment_reply_time {
+                    item.appointment_reply_time = Some(v);
+                }
+                if let Some(v) = patch.meeting_status {
+                    item.meeting_status = Some(v);
+                }
+                if let Some(v) = patch.response_type {
+                    item.response_type = Some(v);
+                }
+                if let Some(v) = patch.online_meeting_conf_link {
+                    item.online_meeting_conf_link = Some(v);
+                }
+                if let Some(v) = patch.online_meeting_external_link {
+                    item.online_meeting_external_link = Some(v);
+                }
+                if let Some(v) = patch.client_uid {
+                    item.client_uid = Some(v);
+                }
+                if let Some(v) = patch.exceptions {
+                    item.exceptions = v;
+                }
                 let ics = render_ics(&item);
-                match caldav.put_event(&existing.resource_href, Some(&existing.resource_href), &ics, username, password,
-                    existing_etag.as_deref().or(existing.etag.as_deref())).await
+                match caldav
+                    .put_event(
+                        &existing.resource_href,
+                        Some(&existing.resource_href),
+                        &ics,
+                        username,
+                        password,
+                        existing_etag.as_deref().or(existing.etag.as_deref()),
+                    )
+                    .await
                 {
                     Ok((resource_href, etag)) => {
-                        state.storage.upsert_item_map(owner, &existing.resource_href, &resource_href, &server_id, &item.uid, &etag).await?;
-                        results.push(ClientMutationResult::Change { server_id, status: "1" });
+                        state
+                            .storage
+                            .upsert_item_map(
+                                owner,
+                                &existing.resource_href,
+                                &resource_href,
+                                &server_id,
+                                &item.uid,
+                                &etag,
+                            )
+                            .await?;
+                        results.push(ClientMutationResult::Change {
+                            server_id,
+                            status: "1",
+                        });
                     }
-                    Err(_) => results.push(ClientMutationResult::Change { server_id, status: "6" }),
+                    Err(_) => results.push(ClientMutationResult::Change {
+                        server_id,
+                        status: "6",
+                    }),
                 }
             }
-            EasSyncMutation::Delete { server_id, instance_id: _ } => {
-                let Some(existing) = state.storage.get_ews_item_by_server_id(owner, &server_id).await? else {
-                    results.push(ClientMutationResult::Delete { server_id, status: "6" });
+            EasSyncMutation::Delete {
+                server_id,
+                instance_id: _,
+            } => {
+                let Some(existing) = state
+                    .storage
+                    .get_ews_item_by_server_id(owner, &server_id)
+                    .await?
+                else {
+                    results.push(ClientMutationResult::Delete {
+                        server_id,
+                        status: "6",
+                    });
                     continue;
                 };
-                match caldav.delete_event(&existing.resource_href, username, password, existing.etag.as_deref()).await {
+                match caldav
+                    .delete_event(
+                        &existing.resource_href,
+                        username,
+                        password,
+                        existing.etag.as_deref(),
+                    )
+                    .await
+                {
                     Ok(()) => {
-                        state.storage.add_delete_tombstone(owner, &server_id).await?;
-                        state.storage.delete_item_by_server_id(owner, &server_id).await?;
-                        results.push(ClientMutationResult::Delete { server_id, status: "1" });
+                        state
+                            .storage
+                            .add_delete_tombstone(owner, &server_id)
+                            .await?;
+                        state
+                            .storage
+                            .delete_item_by_server_id(owner, &server_id)
+                            .await?;
+                        results.push(ClientMutationResult::Delete {
+                            server_id,
+                            status: "1",
+                        });
                     }
-                    Err(_) => results.push(ClientMutationResult::Delete { server_id, status: "6" }),
+                    Err(_) => results.push(ClientMutationResult::Delete {
+                        server_id,
+                        status: "6",
+                    }),
                 }
             }
         }
@@ -194,22 +374,40 @@ pub async fn apply_client_sync_mutations(
 }
 
 pub fn render_client_mutation_responses(results: &[ClientMutationResult]) -> String {
-    if results.is_empty() { return String::new(); }
+    if results.is_empty() {
+        return String::new();
+    }
     let mut xml = String::with_capacity(512);
     xml.push_str("<Responses>");
     for result in results {
         match result {
-            ClientMutationResult::Add { client_id, server_id, status } => {
+            ClientMutationResult::Add {
+                client_id,
+                server_id,
+                status,
+            } => {
                 xml.push_str("<Add>");
-                if let Some(client_id) = client_id { xml.push_str(&format!("<ClientId>{}</ClientId>", xml_escape(client_id))); }
-                if let Some(server_id) = server_id { xml.push_str(&format!("<ServerId>{}</ServerId>", xml_escape(server_id))); }
+                if let Some(client_id) = client_id {
+                    xml.push_str(&format!("<ClientId>{}</ClientId>", xml_escape(client_id)));
+                }
+                if let Some(server_id) = server_id {
+                    xml.push_str(&format!("<ServerId>{}</ServerId>", xml_escape(server_id)));
+                }
                 xml.push_str(&format!("<Status>{}</Status></Add>", status));
             }
             ClientMutationResult::Change { server_id, status } => {
-                xml.push_str(&format!("<Change><ServerId>{}</ServerId><Status>{}</Status></Change>", xml_escape(server_id), status));
+                xml.push_str(&format!(
+                    "<Change><ServerId>{}</ServerId><Status>{}</Status></Change>",
+                    xml_escape(server_id),
+                    status
+                ));
             }
             ClientMutationResult::Delete { server_id, status } => {
-                xml.push_str(&format!("<Delete><ServerId>{}</ServerId><Status>{}</Status></Delete>", xml_escape(server_id), status));
+                xml.push_str(&format!(
+                    "<Delete><ServerId>{}</ServerId><Status>{}</Status></Delete>",
+                    xml_escape(server_id),
+                    status
+                ));
             }
         }
     }
@@ -227,16 +425,35 @@ pub async fn apply_meeting_response(
     _instance_id: Option<chrono::DateTime<Utc>>,
     _send_response: bool,
 ) -> Result<()> {
-    let Some(existing) = state.storage.get_ews_item_by_server_id(owner, request_id).await? else {
+    let Some(existing) = state
+        .storage
+        .get_ews_item_by_server_id(owner, request_id)
+        .await?
+    else {
         return Err(anyhow!("unknown meeting request id: {request_id}"));
     };
     let caldav = CaldavClient::new(&state.cfg)?;
     let calendars = caldav.find_user_calendars(username, password).await?;
-    let collection_href = calendars.first().ok_or_else(|| anyhow!("no calendars found"))?.clone();
-    let (existing_ics, existing_etag) = caldav.get_event(&existing.resource_href, username, password).await?;
-    let mut item = parse_ics_event(&existing_ics).ok_or_else(|| anyhow!("failed parsing existing event"))?;
-    let (status, partstat) = match user_response { 1=>(3,"ACCEPTED"), 2=>(2,"TENTATIVE"), 3=>(4,"DECLINED"), _=>(5,"NEEDS-ACTION") };
-    if let Some(attendee) = item.attendees.iter_mut().find(|a| a.email.eq_ignore_ascii_case(owner)) {
+    let collection_href = calendars
+        .first()
+        .ok_or_else(|| anyhow!("no calendars found"))?
+        .clone();
+    let (existing_ics, existing_etag) = caldav
+        .get_event(&existing.resource_href, username, password)
+        .await?;
+    let mut item =
+        parse_ics_event(&existing_ics).ok_or_else(|| anyhow!("failed parsing existing event"))?;
+    let (status, partstat) = match user_response {
+        1 => (3, "ACCEPTED"),
+        2 => (2, "TENTATIVE"),
+        3 => (4, "DECLINED"),
+        _ => (5, "NEEDS-ACTION"),
+    };
+    if let Some(attendee) = item
+        .attendees
+        .iter_mut()
+        .find(|a| a.email.eq_ignore_ascii_case(owner))
+    {
         attendee.attendee_status = Some(status);
         attendee.partstat = Some(partstat.to_string());
     } else {
@@ -251,14 +468,35 @@ pub async fn apply_meeting_response(
     item.response_type = Some(status);
     item.appointment_reply_time = Some(Utc::now());
     let ics = render_ics(&item);
-    let (resource_href, etag) = caldav.put_event(&collection_href, Some(&existing.resource_href), &ics, username, password,
-        existing_etag.as_deref().or(existing.etag.as_deref())).await?;
-    state.storage.upsert_item_map(owner, &collection_href, &resource_href, request_id, &item.uid, &etag).await?;
+    let (resource_href, etag) = caldav
+        .put_event(
+            &collection_href,
+            Some(&existing.resource_href),
+            &ics,
+            username,
+            password,
+            existing_etag.as_deref().or(existing.etag.as_deref()),
+        )
+        .await?;
+    state
+        .storage
+        .upsert_item_map(
+            owner,
+            &collection_href,
+            &resource_href,
+            request_id,
+            &item.uid,
+            &etag,
+        )
+        .await?;
     Ok(())
 }
 
 pub(crate) fn xml_escape(input: &str) -> String {
-    input.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 fn class_placeholder_app_data(content_class: &str, owner: &str) -> String {
@@ -281,20 +519,33 @@ fn parse_datetime_local(val: &str) -> Option<chrono::DateTime<Utc>> {
         chrono::NaiveDateTime::parse_from_str(val, "%Y%m%dT%H%M%SZ")
             .map(|dt| Utc.from_utc_datetime(&dt))
             .ok()
-            .or_else(|| chrono::DateTime::parse_from_rfc3339(val).ok().map(|dt| dt.with_timezone(&Utc)))
+            .or_else(|| {
+                chrono::DateTime::parse_from_rfc3339(val)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
+            })
     } else if val.contains('T') {
         chrono::NaiveDateTime::parse_from_str(val, "%Y%m%dT%H%M%S")
             .map(|dt| Utc.from_utc_datetime(&dt))
             .ok()
-            .or_else(|| chrono::NaiveDateTime::parse_from_str(val, "%Y-%m-%dT%H:%M:%S").map(|dt| Utc.from_utc_datetime(&dt)).ok())
+            .or_else(|| {
+                chrono::NaiveDateTime::parse_from_str(val, "%Y-%m-%dT%H:%M:%S")
+                    .map(|dt| Utc.from_utc_datetime(&dt))
+                    .ok()
+            })
     } else {
-        chrono::NaiveDate::parse_from_str(val, "%Y%m%d").ok()
+        chrono::NaiveDate::parse_from_str(val, "%Y%m%d")
+            .ok()
             .and_then(|d| d.and_hms_opt(0, 0, 0))
             .map(|dt| Utc.from_utc_datetime(&dt))
     }
 }
 
-fn map_rrule_to_recurrence_xml(rrule: &str, timezone: Option<&str>, all_day: bool) -> Option<String> {
+fn map_rrule_to_recurrence_xml(
+    rrule: &str,
+    timezone: Option<&str>,
+    all_day: bool,
+) -> Option<String> {
     let parts: Vec<&str> = rrule.split(';').collect();
     let mut freq: Option<u8> = None;
     let mut interval = 1u32;
@@ -310,22 +561,58 @@ fn map_rrule_to_recurrence_xml(rrule: &str, timezone: Option<&str>, all_day: boo
             let k = &part[..idx];
             let v = &part[idx + 1..];
             match k {
-                "FREQ" => match v { "DAILY"=>freq=Some(0), "WEEKLY"=>freq=Some(1), "MONTHLY"=>freq=Some(2), "YEARLY"=>freq=Some(5), _=>{} },
+                "FREQ" => match v {
+                    "DAILY" => freq = Some(0),
+                    "WEEKLY" => freq = Some(1),
+                    "MONTHLY" => freq = Some(2),
+                    "YEARLY" => freq = Some(5),
+                    _ => {}
+                },
                 "INTERVAL" => interval = v.parse().unwrap_or(1),
                 "BYDAY" => {
                     let mut mask = 0u8;
                     for d in v.split(',') {
-                        let (ordinal, day_code) = if d.len() > 2 { (&d[..d.len()-2], &d[d.len()-2..]) } else { ("", d) };
-                        if !ordinal.is_empty() { week_of_month = ordinal.parse::<i32>().unwrap_or(0); }
-                        match day_code { "SU"=>mask|=1, "MO"=>mask|=2, "TU"=>mask|=4, "WE"=>mask|=8, "TH"=>mask|=16, "FR"=>mask|=32, "SA"=>mask|=64, _=>{} }
+                        let (ordinal, day_code) = if d.len() > 2 {
+                            (&d[..d.len() - 2], &d[d.len() - 2..])
+                        } else {
+                            ("", d)
+                        };
+                        if !ordinal.is_empty() {
+                            week_of_month = ordinal.parse::<i32>().unwrap_or(0);
+                        }
+                        match day_code {
+                            "SU" => mask |= 1,
+                            "MO" => mask |= 2,
+                            "TU" => mask |= 4,
+                            "WE" => mask |= 8,
+                            "TH" => mask |= 16,
+                            "FR" => mask |= 32,
+                            "SA" => mask |= 64,
+                            _ => {}
+                        }
                     }
                     day_of_week = mask.to_string();
                 }
                 "BYMONTHDAY" => day_of_month = v.parse().unwrap_or(1),
                 "BYMONTH" => month_of_year = v.parse().unwrap_or(1),
-                "UNTIL" => { if let Some(dt) = parse_datetime_local(v) { until = Some(dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()); } }
+                "UNTIL" => {
+                    if let Some(dt) = parse_datetime_local(v) {
+                        until = Some(dt.format("%Y-%m-%dT%H:%M:%SZ").to_string());
+                    }
+                }
                 "COUNT" => occurrences = v.parse().ok(),
-                "WKST" => first_day_of_week = Some(match v { "SU"=>1, "MO"=>2, "TU"=>3, "WE"=>4, "TH"=>5, "FR"=>6, "SA"=>7, _=>2 }),
+                "WKST" => {
+                    first_day_of_week = Some(match v {
+                        "SU" => 1,
+                        "MO" => 2,
+                        "TU" => 3,
+                        "WE" => 4,
+                        "TH" => 5,
+                        "FR" => 6,
+                        "SA" => 7,
+                        _ => 2,
+                    })
+                }
                 _ => {}
             }
         }
@@ -333,25 +620,78 @@ fn map_rrule_to_recurrence_xml(rrule: &str, timezone: Option<&str>, all_day: boo
     let timezone_for_recurrence = timezone.unwrap_or("").to_string();
     let all_day_flag = all_day;
     let mut freq_val = freq?;
-    if week_of_month != 0 { freq_val = match freq_val { 2=>3, 5=>6, other=>other }; }
+    if week_of_month != 0 {
+        freq_val = match freq_val {
+            2 => 3,
+            5 => 6,
+            other => other,
+        };
+    }
     let mut xml = String::with_capacity(512);
     xml.push_str("<Calendar:Recurrence>");
     xml.push_str(&format!("<Calendar:Type>{freq_val}</Calendar:Type>"));
-    xml.push_str(&format!("<Calendar:Interval>{interval}</Calendar:Interval>"));
-    if !day_of_week.is_empty() { xml.push_str(&format!("<Calendar:DayOfWeek>{}</Calendar:DayOfWeek>", day_of_week)); }
-    if matches!(freq_val, 2|3|5|6) { xml.push_str(&format!("<Calendar:DayOfMonth>{}</Calendar:DayOfMonth>", day_of_month)); }
-    if matches!(freq_val, 3|6) && week_of_month != 0 {
-        let normalized = if week_of_month < 0 { 5 } else { week_of_month as u32 };
-        xml.push_str(&format!("<Calendar:WeekOfMonth>{}</Calendar:WeekOfMonth>", normalized));
+    xml.push_str(&format!(
+        "<Calendar:Interval>{interval}</Calendar:Interval>"
+    ));
+    if !day_of_week.is_empty() {
+        xml.push_str(&format!(
+            "<Calendar:DayOfWeek>{}</Calendar:DayOfWeek>",
+            day_of_week
+        ));
     }
-    if matches!(freq_val, 5|6) { xml.push_str(&format!("<Calendar:MonthOfYear>{}</Calendar:MonthOfYear>", month_of_year)); }
-    if matches!(freq_val, 2|3|5|6) { xml.push_str("<Calendar:CalendarType>0</Calendar:CalendarType>"); }
-    if let Some(v) = until { xml.push_str(&format!("<Calendar:Until>{}</Calendar:Until>", xml_escape(&v))); }
-    if let Some(v) = occurrences { xml.push_str(&format!("<Calendar:Occurrences>{}</Calendar:Occurrences>", v)); }
-    if let Some(v) = first_day_of_week { xml.push_str(&format!("<Calendar:FirstDayOfWeek>{}</Calendar:FirstDayOfWeek>", v)); }
+    if matches!(freq_val, 2 | 3 | 5 | 6) {
+        xml.push_str(&format!(
+            "<Calendar:DayOfMonth>{}</Calendar:DayOfMonth>",
+            day_of_month
+        ));
+    }
+    if matches!(freq_val, 3 | 6) && week_of_month != 0 {
+        let normalized = if week_of_month < 0 {
+            5
+        } else {
+            week_of_month as u32
+        };
+        xml.push_str(&format!(
+            "<Calendar:WeekOfMonth>{}</Calendar:WeekOfMonth>",
+            normalized
+        ));
+    }
+    if matches!(freq_val, 5 | 6) {
+        xml.push_str(&format!(
+            "<Calendar:MonthOfYear>{}</Calendar:MonthOfYear>",
+            month_of_year
+        ));
+    }
+    if matches!(freq_val, 2 | 3 | 5 | 6) {
+        xml.push_str("<Calendar:CalendarType>0</Calendar:CalendarType>");
+    }
+    if let Some(v) = until {
+        xml.push_str(&format!(
+            "<Calendar:Until>{}</Calendar:Until>",
+            xml_escape(&v)
+        ));
+    }
+    if let Some(v) = occurrences {
+        xml.push_str(&format!(
+            "<Calendar:Occurrences>{}</Calendar:Occurrences>",
+            v
+        ));
+    }
+    if let Some(v) = first_day_of_week {
+        xml.push_str(&format!(
+            "<Calendar:FirstDayOfWeek>{}</Calendar:FirstDayOfWeek>",
+            v
+        ));
+    }
     if !all_day_flag && !timezone_for_recurrence.is_empty() {
-        xml.push_str(&format!("<Calendar:StartTimeZone>{}</Calendar:StartTimeZone>", xml_escape(&timezone_for_recurrence)));
-        xml.push_str(&format!("<Calendar:EndTimeZone>{}</Calendar:EndTimeZone>", xml_escape(&timezone_for_recurrence)));
+        xml.push_str(&format!(
+            "<Calendar:StartTimeZone>{}</Calendar:StartTimeZone>",
+            xml_escape(&timezone_for_recurrence)
+        ));
+        xml.push_str(&format!(
+            "<Calendar:EndTimeZone>{}</Calendar:EndTimeZone>",
+            xml_escape(&timezone_for_recurrence)
+        ));
     }
     xml.push_str("</Calendar:Recurrence>");
     Some(xml)
@@ -360,69 +700,187 @@ fn map_rrule_to_recurrence_xml(rrule: &str, timezone: Option<&str>, all_day: boo
 fn render_attendee_xml(attendee: &Attendee) -> String {
     let mut xml = String::with_capacity(256);
     xml.push_str("<Calendar:Attendee>");
-    if !attendee.email.is_empty() { xml.push_str(&format!("<Calendar:Email>{}</Calendar:Email>", xml_escape(&attendee.email))); }
-    if let Some(name) = attendee.name.as_deref().filter(|v| !v.is_empty()) { xml.push_str(&format!("<Calendar:Name>{}</Calendar:Name>", xml_escape(name))); }
-    else if !attendee.email.is_empty() { xml.push_str(&format!("<Calendar:Name>{}</Calendar:Name>", xml_escape(&attendee.email))); }
-    if let Some(v) = attendee.attendee_type { xml.push_str(&format!("<Calendar:AttendeeType>{}</Calendar:AttendeeType>", v)); }
-    if let Some(v) = attendee.attendee_status { xml.push_str(&format!("<Calendar:AttendeeStatus>{}</Calendar:AttendeeStatus>", v)); }
+    if !attendee.email.is_empty() {
+        xml.push_str(&format!(
+            "<Calendar:Email>{}</Calendar:Email>",
+            xml_escape(&attendee.email)
+        ));
+    }
+    if let Some(name) = attendee.name.as_deref().filter(|v| !v.is_empty()) {
+        xml.push_str(&format!(
+            "<Calendar:Name>{}</Calendar:Name>",
+            xml_escape(name)
+        ));
+    } else if !attendee.email.is_empty() {
+        xml.push_str(&format!(
+            "<Calendar:Name>{}</Calendar:Name>",
+            xml_escape(&attendee.email)
+        ));
+    }
+    if let Some(v) = attendee.attendee_type {
+        xml.push_str(&format!(
+            "<Calendar:AttendeeType>{}</Calendar:AttendeeType>",
+            v
+        ));
+    }
+    if let Some(v) = attendee.attendee_status {
+        xml.push_str(&format!(
+            "<Calendar:AttendeeStatus>{}</Calendar:AttendeeStatus>",
+            v
+        ));
+    }
     xml.push_str("</Calendar:Attendee>");
     xml
 }
 
 fn derived_meeting_status(item: &CalendarItem) -> u8 {
-    if let Some(v) = item.meeting_status { return v; }
+    if let Some(v) = item.meeting_status {
+        return v;
+    }
     let is_meeting = !item.attendees.is_empty();
-    let organizer = item.organizer_email.as_deref().map(|v| !v.is_empty()).unwrap_or(false);
-    if !is_meeting { 0 } else if organizer { 1 } else { 3 }
+    let organizer = item
+        .organizer_email
+        .as_deref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if !is_meeting {
+        0
+    } else if organizer {
+        1
+    } else {
+        3
+    }
 }
 
 fn derived_response_type(item: &CalendarItem) -> Option<u8> {
-    if let Some(v) = item.response_type { return Some(v); }
-    if derived_meeting_status(item) == 1 { return Some(1); }
-    item.attendees.iter().find_map(|a| match a.attendee_status { Some(2)=>Some(2), Some(3)=>Some(3), Some(4)=>Some(4), Some(5)=>Some(5), _=>None })
+    if let Some(v) = item.response_type {
+        return Some(v);
+    }
+    if derived_meeting_status(item) == 1 {
+        return Some(1);
+    }
+    item.attendees.iter().find_map(|a| match a.attendee_status {
+        Some(2) => Some(2),
+        Some(3) => Some(3),
+        Some(4) => Some(4),
+        Some(5) => Some(5),
+        _ => None,
+    })
 }
 
 fn render_exception_xml(exception: &CalendarException, item: &CalendarItem) -> String {
     let mut xml = String::with_capacity(1024);
     xml.push_str("<Calendar:Exception>");
-    xml.push_str(&format!("<Calendar:ExceptionStartTime>{}</Calendar:ExceptionStartTime>", exception.exception_start.format("%Y-%m-%dT%H:%M:%SZ")));
+    xml.push_str(&format!(
+        "<Calendar:ExceptionStartTime>{}</Calendar:ExceptionStartTime>",
+        exception.exception_start.format("%Y-%m-%dT%H:%M:%SZ")
+    ));
     if exception.deleted {
         xml.push_str("<Calendar:Deleted>1</Calendar:Deleted></Calendar:Exception>");
         return xml;
     }
-    if let Some(v) = &exception.subject { xml.push_str(&format!("<Calendar:Subject>{}</Calendar:Subject>", xml_escape(v))); }
-    if let Some(v) = exception.start { xml.push_str(&format!("<Calendar:StartTime>{}</Calendar:StartTime>", v.format("%Y-%m-%dT%H:%M:%SZ"))); }
-    if let Some(v) = exception.end { xml.push_str(&format!("<Calendar:EndTime>{}</Calendar:EndTime>", v.format("%Y-%m-%dT%H:%M:%SZ"))); }
-    if let Some(v) = exception.all_day { xml.push_str(if v { "<Calendar:AllDayEvent>1</Calendar:AllDayEvent>" } else { "<Calendar:AllDayEvent>0</Calendar:AllDayEvent>" }); }
-    if let Some(v) = &exception.location { xml.push_str(&format!("<AirSyncBase:Location><AirSyncBase:DisplayName>{}</AirSyncBase:DisplayName></AirSyncBase:Location>", xml_escape(v))); }
-    if let Some(v) = exception.busy_status { xml.push_str(&format!("<Calendar:BusyStatus>{}</Calendar:BusyStatus>", v)); }
-    if let Some(v) = exception.sensitivity { xml.push_str(&format!("<Calendar:Sensitivity>{}</Calendar:Sensitivity>", v)); }
-    if let Some(v) = exception.reminder { xml.push_str(&format!("<Calendar:Reminder>{}</Calendar:Reminder>", v)); }
-    if let Some(v) = exception.appointment_reply_time { xml.push_str(&format!("<Calendar:AppointmentReplyTime>{}</Calendar:AppointmentReplyTime>", v.format("%Y-%m-%dT%H:%M:%SZ"))); }
-    if let Some(v) = exception.meeting_status { xml.push_str(&format!("<Calendar:MeetingStatus>{}</Calendar:MeetingStatus>", v)); }
-    else { xml.push_str(&format!("<Calendar:MeetingStatus>{}</Calendar:MeetingStatus>", derived_meeting_status(item))); }
-    if let Some(v) = exception.response_type.or_else(|| derived_response_type(item)) { xml.push_str(&format!("<Calendar:ResponseType>{}</Calendar:ResponseType>", v)); }
+    if let Some(v) = &exception.subject {
+        xml.push_str(&format!(
+            "<Calendar:Subject>{}</Calendar:Subject>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = exception.start {
+        xml.push_str(&format!(
+            "<Calendar:StartTime>{}</Calendar:StartTime>",
+            v.format("%Y-%m-%dT%H:%M:%SZ")
+        ));
+    }
+    if let Some(v) = exception.end {
+        xml.push_str(&format!(
+            "<Calendar:EndTime>{}</Calendar:EndTime>",
+            v.format("%Y-%m-%dT%H:%M:%SZ")
+        ));
+    }
+    if let Some(v) = exception.all_day {
+        xml.push_str(if v {
+            "<Calendar:AllDayEvent>1</Calendar:AllDayEvent>"
+        } else {
+            "<Calendar:AllDayEvent>0</Calendar:AllDayEvent>"
+        });
+    }
+    if let Some(v) = &exception.location {
+        xml.push_str(&format!("<AirSyncBase:Location><AirSyncBase:DisplayName>{}</AirSyncBase:DisplayName></AirSyncBase:Location>", xml_escape(v)));
+    }
+    if let Some(v) = exception.busy_status {
+        xml.push_str(&format!("<Calendar:BusyStatus>{}</Calendar:BusyStatus>", v));
+    }
+    if let Some(v) = exception.sensitivity {
+        xml.push_str(&format!(
+            "<Calendar:Sensitivity>{}</Calendar:Sensitivity>",
+            v
+        ));
+    }
+    if let Some(v) = exception.reminder {
+        xml.push_str(&format!("<Calendar:Reminder>{}</Calendar:Reminder>", v));
+    }
+    if let Some(v) = exception.appointment_reply_time {
+        xml.push_str(&format!(
+            "<Calendar:AppointmentReplyTime>{}</Calendar:AppointmentReplyTime>",
+            v.format("%Y-%m-%dT%H:%M:%SZ")
+        ));
+    }
+    if let Some(v) = exception.meeting_status {
+        xml.push_str(&format!(
+            "<Calendar:MeetingStatus>{}</Calendar:MeetingStatus>",
+            v
+        ));
+    } else {
+        xml.push_str(&format!(
+            "<Calendar:MeetingStatus>{}</Calendar:MeetingStatus>",
+            derived_meeting_status(item)
+        ));
+    }
+    if let Some(v) = exception
+        .response_type
+        .or_else(|| derived_response_type(item))
+    {
+        xml.push_str(&format!(
+            "<Calendar:ResponseType>{}</Calendar:ResponseType>",
+            v
+        ));
+    }
     if let Some(cats) = &exception.categories
         && !cats.is_empty()
     {
         xml.push_str("<Calendar:Categories>");
-        for cat in cats { xml.push_str(&format!("<Calendar:Category>{}</Calendar:Category>", xml_escape(cat))); }
+        for cat in cats {
+            xml.push_str(&format!(
+                "<Calendar:Category>{}</Calendar:Category>",
+                xml_escape(cat)
+            ));
+        }
         xml.push_str("</Calendar:Categories>");
     } else if !item.categories.is_empty() {
         xml.push_str("<Calendar:Categories>");
-        for cat in &item.categories { xml.push_str(&format!("<Calendar:Category>{}</Calendar:Category>", xml_escape(cat))); }
+        for cat in &item.categories {
+            xml.push_str(&format!(
+                "<Calendar:Category>{}</Calendar:Category>",
+                xml_escape(cat)
+            ));
+        }
         xml.push_str("</Calendar:Categories>");
     }
     if let Some(attendees) = &exception.attendees
         && !attendees.is_empty()
     {
         xml.push_str("<Calendar:Attendees>");
-        for a in attendees { xml.push_str(&render_attendee_xml(a)); }
+        for a in attendees {
+            xml.push_str(&render_attendee_xml(a));
+        }
         xml.push_str("</Calendar:Attendees>");
     }
     if let Some(desc) = &exception.description {
         xml.push_str("<AirSyncBase:Body><AirSyncBase:Type>1</AirSyncBase:Type>");
-        xml.push_str(&format!("<AirSyncBase:EstimatedDataSize>{}</AirSyncBase:EstimatedDataSize>", desc.len()));
+        xml.push_str(&format!(
+            "<AirSyncBase:EstimatedDataSize>{}</AirSyncBase:EstimatedDataSize>",
+            desc.len()
+        ));
         xml.push_str("<AirSyncBase:Truncated>0</AirSyncBase:Truncated><AirSyncBase:Data>");
         xml.push_str(&xml_escape(desc));
         xml.push_str("</AirSyncBase:Data></AirSyncBase:Body>");
@@ -433,60 +891,166 @@ fn render_exception_xml(exception: &CalendarException, item: &CalendarItem) -> S
 
 pub(crate) fn render_calendar_app_data(item: &CalendarItem) -> String {
     let mut xml = String::with_capacity(2048);
-    xml.push_str(&format!("<Calendar:Subject>{}</Calendar:Subject>", xml_escape(&item.subject)));
-    xml.push_str(&format!("<Calendar:StartTime>{}</Calendar:StartTime>", item.start.format("%Y-%m-%dT%H:%M:%SZ")));
-    xml.push_str(&format!("<Calendar:EndTime>{}</Calendar:EndTime>", item.end.format("%Y-%m-%dT%H:%M:%SZ")));
-    xml.push_str(&format!("<Calendar:DtStamp>{}</Calendar:DtStamp>", item.dtstamp.unwrap_or_else(Utc::now).format("%Y-%m-%dT%H:%M:%SZ")));
-    xml.push_str(if item.all_day { "<Calendar:AllDayEvent>1</Calendar:AllDayEvent>" } else { "<Calendar:AllDayEvent>0</Calendar:AllDayEvent>" });
-    if !item.all_day { if let Some(v) = &item.timezone { xml.push_str(&format!("<Calendar:Timezone>{}</Calendar:Timezone>", xml_escape(v))); } }
-    if let Some(v) = item.busy_status { xml.push_str(&format!("<Calendar:BusyStatus>{}</Calendar:BusyStatus>", v)); }
-    if let Some(v) = item.sensitivity { xml.push_str(&format!("<Calendar:Sensitivity>{}</Calendar:Sensitivity>", v)); }
-    if let Some(v) = item.reminder { xml.push_str(&format!("<Calendar:Reminder>{}</Calendar:Reminder>", v)); }
-    if !item.location.is_empty() { xml.push_str(&format!("<AirSyncBase:Location><AirSyncBase:DisplayName>{}</AirSyncBase:DisplayName></AirSyncBase:Location>", xml_escape(&item.location))); }
-    if let Some(v) = &item.organizer_name { xml.push_str(&format!("<Calendar:OrganizerName>{}</Calendar:OrganizerName>", xml_escape(v))); }
-    if let Some(v) = &item.organizer_email { xml.push_str(&format!("<Calendar:OrganizerEmail>{}</Calendar:OrganizerEmail>", xml_escape(v))); }
+    xml.push_str(&format!(
+        "<Calendar:Subject>{}</Calendar:Subject>",
+        xml_escape(&item.subject)
+    ));
+    xml.push_str(&format!(
+        "<Calendar:StartTime>{}</Calendar:StartTime>",
+        item.start.format("%Y-%m-%dT%H:%M:%SZ")
+    ));
+    xml.push_str(&format!(
+        "<Calendar:EndTime>{}</Calendar:EndTime>",
+        item.end.format("%Y-%m-%dT%H:%M:%SZ")
+    ));
+    xml.push_str(&format!(
+        "<Calendar:DtStamp>{}</Calendar:DtStamp>",
+        item.dtstamp
+            .unwrap_or_else(Utc::now)
+            .format("%Y-%m-%dT%H:%M:%SZ")
+    ));
+    xml.push_str(if item.all_day {
+        "<Calendar:AllDayEvent>1</Calendar:AllDayEvent>"
+    } else {
+        "<Calendar:AllDayEvent>0</Calendar:AllDayEvent>"
+    });
+    if !item.all_day
+        && let Some(v) = &item.timezone
+    {
+        xml.push_str(&format!(
+            "<Calendar:Timezone>{}</Calendar:Timezone>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = item.busy_status {
+        xml.push_str(&format!("<Calendar:BusyStatus>{}</Calendar:BusyStatus>", v));
+    }
+    if let Some(v) = item.sensitivity {
+        xml.push_str(&format!(
+            "<Calendar:Sensitivity>{}</Calendar:Sensitivity>",
+            v
+        ));
+    }
+    if let Some(v) = item.reminder {
+        xml.push_str(&format!("<Calendar:Reminder>{}</Calendar:Reminder>", v));
+    }
+    if !item.location.is_empty() {
+        xml.push_str(&format!("<AirSyncBase:Location><AirSyncBase:DisplayName>{}</AirSyncBase:DisplayName></AirSyncBase:Location>", xml_escape(&item.location)));
+    }
+    if let Some(v) = &item.organizer_name {
+        xml.push_str(&format!(
+            "<Calendar:OrganizerName>{}</Calendar:OrganizerName>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = &item.organizer_email {
+        xml.push_str(&format!(
+            "<Calendar:OrganizerEmail>{}</Calendar:OrganizerEmail>",
+            xml_escape(v)
+        ));
+    }
     if !item.attendees.is_empty() {
         xml.push_str("<Calendar:Attendees>");
-        for a in &item.attendees { xml.push_str(&render_attendee_xml(a)); }
+        for a in &item.attendees {
+            xml.push_str(&render_attendee_xml(a));
+        }
         xml.push_str("</Calendar:Attendees>");
     }
     if !item.categories.is_empty() {
         xml.push_str("<Calendar:Categories>");
-        for c in &item.categories { xml.push_str(&format!("<Calendar:Category>{}</Calendar:Category>", xml_escape(c))); }
+        for c in &item.categories {
+            xml.push_str(&format!(
+                "<Calendar:Category>{}</Calendar:Category>",
+                xml_escape(c)
+            ));
+        }
         xml.push_str("</Calendar:Categories>");
     }
     xml.push_str("<AirSyncBase:Body><AirSyncBase:Type>1</AirSyncBase:Type>");
-    xml.push_str(&format!("<AirSyncBase:EstimatedDataSize>{}</AirSyncBase:EstimatedDataSize>", item.description.len()));
+    xml.push_str(&format!(
+        "<AirSyncBase:EstimatedDataSize>{}</AirSyncBase:EstimatedDataSize>",
+        item.description.len()
+    ));
     xml.push_str("<AirSyncBase:Truncated>0</AirSyncBase:Truncated><AirSyncBase:Data>");
     xml.push_str(&xml_escape(&item.description));
     xml.push_str("</AirSyncBase:Data></AirSyncBase:Body>");
     xml.push_str("<AirSyncBase:NativeBodyType>1</AirSyncBase:NativeBodyType>");
-    if !item.all_day {
-        if let Some(tz) = &item.timezone {
-            xml.push_str(&format!("<Calendar:StartTimeZone>{}</Calendar:StartTimeZone>", xml_escape(tz)));
-            xml.push_str(&format!("<Calendar:EndTimeZone>{}</Calendar:EndTimeZone>", xml_escape(tz)));
-        }
+    if !item.all_day
+        && let Some(tz) = &item.timezone
+    {
+        xml.push_str(&format!(
+            "<Calendar:StartTimeZone>{}</Calendar:StartTimeZone>",
+            xml_escape(tz)
+        ));
+        xml.push_str(&format!(
+            "<Calendar:EndTimeZone>{}</Calendar:EndTimeZone>",
+            xml_escape(tz)
+        ));
     }
-    xml.push_str(&format!("<Calendar:UID>{}</Calendar:UID>", xml_escape(&item.uid)));
+    xml.push_str(&format!(
+        "<Calendar:UID>{}</Calendar:UID>",
+        xml_escape(&item.uid)
+    ));
     if let Some(rrule) = &item.rrule
-        && let Some(rec_xml) = map_rrule_to_recurrence_xml(rrule, item.timezone.as_deref(), item.all_day)
+        && let Some(rec_xml) =
+            map_rrule_to_recurrence_xml(rrule, item.timezone.as_deref(), item.all_day)
     {
         xml.push_str(&rec_xml);
     }
     if !item.exceptions.is_empty() {
         xml.push_str("<Calendar:Exceptions>");
-        for ex in &item.exceptions { xml.push_str(&render_exception_xml(ex, item)); }
+        for ex in &item.exceptions {
+            xml.push_str(&render_exception_xml(ex, item));
+        }
         xml.push_str("</Calendar:Exceptions>");
     }
     xml.push_str("<Calendar:FirstDayOfWeek>1</Calendar:FirstDayOfWeek>");
-    xml.push_str(&format!("<Calendar:MeetingStatus>{}</Calendar:MeetingStatus>", derived_meeting_status(item)));
-    if let Some(v) = item.response_requested { xml.push_str(&format!("<Calendar:ResponseRequested>{}</Calendar:ResponseRequested>", if v { 1 } else { 0 })); }
-    if let Some(v) = item.disallow_new_time_proposal { xml.push_str(&format!("<Calendar:DisallowNewTimeProposal>{}</Calendar:DisallowNewTimeProposal>", if v { 1 } else { 0 })); }
-    if let Some(v) = item.appointment_reply_time { xml.push_str(&format!("<Calendar:AppointmentReplyTime>{}</Calendar:AppointmentReplyTime>", v.format("%Y-%m-%dT%H:%M:%SZ"))); }
-    if let Some(v) = derived_response_type(item) { xml.push_str(&format!("<Calendar:ResponseType>{}</Calendar:ResponseType>", v)); }
-    if let Some(v) = &item.online_meeting_conf_link { xml.push_str(&format!("<Calendar:OnlineMeetingConfLink>{}</Calendar:OnlineMeetingConfLink>", xml_escape(v))); }
-    if let Some(v) = &item.online_meeting_external_link { xml.push_str(&format!("<Calendar:OnlineMeetingExternalLink>{}</Calendar:OnlineMeetingExternalLink>", xml_escape(v))); }
-    if let Some(v) = &item.client_uid { xml.push_str(&format!("<Calendar:ClientUid>{}</Calendar:ClientUid>", xml_escape(v))); }
+    xml.push_str(&format!(
+        "<Calendar:MeetingStatus>{}</Calendar:MeetingStatus>",
+        derived_meeting_status(item)
+    ));
+    if let Some(v) = item.response_requested {
+        xml.push_str(&format!(
+            "<Calendar:ResponseRequested>{}</Calendar:ResponseRequested>",
+            if v { 1 } else { 0 }
+        ));
+    }
+    if let Some(v) = item.disallow_new_time_proposal {
+        xml.push_str(&format!(
+            "<Calendar:DisallowNewTimeProposal>{}</Calendar:DisallowNewTimeProposal>",
+            if v { 1 } else { 0 }
+        ));
+    }
+    if let Some(v) = item.appointment_reply_time {
+        xml.push_str(&format!(
+            "<Calendar:AppointmentReplyTime>{}</Calendar:AppointmentReplyTime>",
+            v.format("%Y-%m-%dT%H:%M:%SZ")
+        ));
+    }
+    if let Some(v) = derived_response_type(item) {
+        xml.push_str(&format!(
+            "<Calendar:ResponseType>{}</Calendar:ResponseType>",
+            v
+        ));
+    }
+    if let Some(v) = &item.online_meeting_conf_link {
+        xml.push_str(&format!(
+            "<Calendar:OnlineMeetingConfLink>{}</Calendar:OnlineMeetingConfLink>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = &item.online_meeting_external_link {
+        xml.push_str(&format!(
+            "<Calendar:OnlineMeetingExternalLink>{}</Calendar:OnlineMeetingExternalLink>",
+            xml_escape(v)
+        ));
+    }
+    if let Some(v) = &item.client_uid {
+        xml.push_str(&format!(
+            "<Calendar:ClientUid>{}</Calendar:ClientUid>",
+            xml_escape(v)
+        ));
+    }
     xml
 }
 
@@ -523,14 +1087,26 @@ pub async fn perform_sync(
 
     if !content_class.eq_ignore_ascii_case("Calendar") {
         let class_name = content_class.trim();
-        let normalized = if class_name.is_empty() { "Calendar" } else { class_name };
+        let normalized = if class_name.is_empty() {
+            "Calendar"
+        } else {
+            class_name
+        };
         let new_sync_key = Uuid::new_v4().to_string();
-        storage.set_sync_key(owner, state_collection_id, &new_sync_key, Some("token")).await?;
+        storage
+            .set_sync_key(owner, state_collection_id, &new_sync_key, Some("token"))
+            .await?;
         let pseudo_resource = format!("class://{}/{}", owner, normalized.to_ascii_lowercase());
         let server_id = generate_server_id(state.cfg.hmac_secret(), &pseudo_resource);
         let app_data = class_placeholder_app_data(normalized, owner);
-        let commands = if app_data.is_empty() { String::new() } else {
-            format!("<Add><ServerId>{}</ServerId><ApplicationData>{}</ApplicationData></Add>", xml_escape(&server_id), app_data)
+        let commands = if app_data.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "<Add><ServerId>{}</ServerId><ApplicationData>{}</ApplicationData></Add>",
+                xml_escape(&server_id),
+                app_data
+            )
         };
         return Ok(format!(
             r#"<?xml version="1.0" encoding="utf-8"?>
@@ -543,7 +1119,11 @@ pub async fn perform_sync(
 {}<Commands>{}</Commands>
 </Collection></Collections>
 </Sync>"#,
-            xml_escape(normalized), new_sync_key, xml_escape(collection_id), client_mutation_responses, commands
+            xml_escape(normalized),
+            new_sync_key,
+            xml_escape(collection_id),
+            client_mutation_responses,
+            commands
         ));
     }
 
@@ -555,14 +1135,27 @@ pub async fn perform_sync(
         }
     }
 
-    let since = if incoming_sync_key == "0" { 0 } else {
-        sync_since_from_token(previous_state.as_ref().and_then(|(_, token)| token.as_deref()))
+    let since = if incoming_sync_key == "0" {
+        0
+    } else {
+        sync_since_from_token(
+            previous_state
+                .as_ref()
+                .and_then(|(_, token)| token.as_deref()),
+        )
     };
 
     if !opts.get_changes && incoming_sync_key != "0" {
         let latest_seq = storage.get_latest_change_seq().await.unwrap_or(0);
         let new_sync_key = Uuid::new_v4().to_string();
-        storage.set_sync_key(owner, state_collection_id, &new_sync_key, Some(&sync_seq_to_token(latest_seq))).await?;
+        storage
+            .set_sync_key(
+                owner,
+                state_collection_id,
+                &new_sync_key,
+                Some(&sync_seq_to_token(latest_seq)),
+            )
+            .await?;
         return Ok(format!(
             r#"<?xml version="1.0" encoding="utf-8"?>
 <Sync xmlns="AirSync:" xmlns:Calendar="Calendar:" xmlns:AirSyncBase="AirSyncBase:">
@@ -581,34 +1174,67 @@ pub async fn perform_sync(
     let latest_seq = storage.get_latest_change_seq().await.unwrap_or(0);
     let caldav = CaldavClient::new(&state.cfg)?;
     let calendars = caldav.find_user_calendars(username, password).await?;
-    let collection_href = calendars.first().ok_or_else(|| anyhow!("no calendars found"))?.clone();
+    let collection_href = calendars
+        .first()
+        .ok_or_else(|| anyhow!("no calendars found"))?
+        .clone();
     let start = opts.filter_start.format("%Y%m%dT%H%M%SZ").to_string();
-    let end = (Utc::now() + Duration::weeks(104)).format("%Y%m%dT%H%M%SZ").to_string();
-    let events_xml = caldav.query_events(&collection_href, &start, &end, username, password).await?;
+    let end = (Utc::now() + Duration::weeks(104))
+        .format("%Y%m%dT%H%M%SZ")
+        .to_string();
+    let events_xml = caldav
+        .query_events(&collection_href, &start, &end, username, password)
+        .await?;
 
-    use quick_xml::events::Event;
     use quick_xml::Reader;
+    use quick_xml::events::Event;
 
     #[derive(Clone)]
-    struct EventItem { href: String, etag: String, ics: String }
+    struct EventItem {
+        href: String,
+        etag: String,
+        ics: String,
+    }
 
     let mut reader = Reader::from_str(&events_xml);
     reader.config_mut().trim_text(true);
     let mut events = Vec::new();
-    let mut current = EventItem { href: String::new(), etag: String::new(), ics: String::new() };
+    let mut current = EventItem {
+        href: String::new(),
+        etag: String::new(),
+        ics: String::new(),
+    };
     let mut buf = Vec::new();
 
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => match e.name().local_name().as_ref() {
-                b"href" => { if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) { current.href = e.decode().unwrap_or_default().to_string(); } }
-                b"getetag" => { if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) { current.etag = e.decode().unwrap_or_default().to_string(); } }
-                b"calendar-data" => { if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) { current.ics = e.decode().unwrap_or_default().to_string(); } }
+                b"href" => {
+                    if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) {
+                        current.href = e.decode().unwrap_or_default().to_string();
+                    }
+                }
+                b"getetag" => {
+                    if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) {
+                        current.etag = e.decode().unwrap_or_default().to_string();
+                    }
+                }
+                b"calendar-data" => {
+                    if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) {
+                        current.ics = e.decode().unwrap_or_default().to_string();
+                    }
+                }
                 _ => {}
             },
             Ok(Event::End(ref e)) if e.name().local_name().as_ref() == b"response" => {
-                if !current.href.is_empty() { events.push(current.clone()); }
-                current = EventItem { href: String::new(), etag: String::new(), ics: String::new() };
+                if !current.href.is_empty() {
+                    events.push(current.clone());
+                }
+                current = EventItem {
+                    href: String::new(),
+                    etag: String::new(),
+                    ics: String::new(),
+                };
             }
             Ok(Event::Eof) => break,
             _ => {}
@@ -616,17 +1242,30 @@ pub async fn perform_sync(
         buf.clear();
     }
 
-    let existing_map = storage.list_ews_items(owner, 4096, 0).await?.into_iter()
-        .map(|item| (item.server_id.clone(), item)).collect::<HashMap<_, _>>();
+    let existing_map = storage
+        .list_ews_items(owner, 4096, 0)
+        .await?
+        .into_iter()
+        .map(|item| (item.server_id.clone(), item))
+        .collect::<HashMap<_, _>>();
 
-    struct PendingItem { server_id: String, resource_href: String, uid: String, etag: String, item: CalendarItem, is_add: bool }
+    struct PendingItem {
+        server_id: String,
+        resource_href: String,
+        uid: String,
+        etag: String,
+        item: CalendarItem,
+        is_add: bool,
+    }
     let mut pending_items: Vec<PendingItem> = Vec::new();
     let mut pending_deletes: Vec<String> = Vec::new();
     let mut seen_ids = HashSet::new();
     let initial_sync = incoming_sync_key == "0";
 
     for ev in &events {
-        if ev.href.is_empty() { continue; }
+        if ev.href.is_empty() {
+            continue;
+        }
         let server_id = generate_server_id(state.cfg.hmac_secret(), &ev.href);
         seen_ids.insert(server_id.clone());
         let etag = ev.etag.trim_matches('"').to_string();
@@ -636,9 +1275,20 @@ pub async fn perform_sync(
         };
         let existing = existing_map.get(&server_id);
         let is_add = existing.is_none();
-        let changed = existing.map(|row| row.etag.as_deref() != Some(etag.as_str())).unwrap_or(true);
-        if !initial_sync && !changed { continue; }
-        pending_items.push(PendingItem { server_id, resource_href: ev.href.clone(), uid: item.uid.clone(), etag, item, is_add });
+        let changed = existing
+            .map(|row| row.etag.as_deref() != Some(etag.as_str()))
+            .unwrap_or(true);
+        if !initial_sync && !changed {
+            continue;
+        }
+        pending_items.push(PendingItem {
+            server_id,
+            resource_href: ev.href.clone(),
+            uid: item.uid.clone(),
+            etag,
+            item,
+            is_add,
+        });
     }
 
     for server_id in existing_map.keys() {
@@ -651,36 +1301,77 @@ pub async fn perform_sync(
     if !initial_sync {
         let tombstones = storage.list_deleted_since_seq(owner, since).await?;
         for (_, sid) in tombstones {
-            if !seen_ids.contains(sid.as_str()) { pending_deletes.push(sid); }
+            if !seen_ids.contains(sid.as_str()) {
+                pending_deletes.push(sid);
+            }
         }
     }
 
-    let mut commands = String::with_capacity((pending_items.len() + pending_deletes.len()).min(window_size) * 4096);
+    let mut commands = String::with_capacity(
+        (pending_items.len() + pending_deletes.len()).min(window_size) * 4096,
+    );
     let mut items_included = 0usize;
     let mut more_available = false;
 
     for pi in &pending_items {
-        if items_included >= window_size { more_available = true; break; }
-        storage.upsert_item_map(owner, &collection_href, &pi.resource_href, &pi.server_id, &pi.uid, &pi.etag).await?;
+        if items_included >= window_size {
+            more_available = true;
+            break;
+        }
+        storage
+            .upsert_item_map(
+                owner,
+                &collection_href,
+                &pi.resource_href,
+                &pi.server_id,
+                &pi.uid,
+                &pi.etag,
+            )
+            .await?;
         if pi.is_add {
-            commands.push_str(&format!("<Add><ServerId>{}</ServerId><ApplicationData>{}</ApplicationData></Add>", pi.server_id, render_calendar_app_data(&pi.item)));
+            commands.push_str(&format!(
+                "<Add><ServerId>{}</ServerId><ApplicationData>{}</ApplicationData></Add>",
+                pi.server_id,
+                render_calendar_app_data(&pi.item)
+            ));
         } else {
-            commands.push_str(&format!("<Change><ServerId>{}</ServerId><ApplicationData>{}</ApplicationData></Change>", pi.server_id, render_calendar_app_data(&pi.item)));
+            commands.push_str(&format!(
+                "<Change><ServerId>{}</ServerId><ApplicationData>{}</ApplicationData></Change>",
+                pi.server_id,
+                render_calendar_app_data(&pi.item)
+            ));
         }
         items_included += 1;
     }
 
     if !more_available {
         for server_id in &pending_deletes {
-            if items_included >= window_size { more_available = true; break; }
-            commands.push_str(&format!("<Delete><ServerId>{}</ServerId></Delete>", xml_escape(server_id)));
+            if items_included >= window_size {
+                more_available = true;
+                break;
+            }
+            commands.push_str(&format!(
+                "<Delete><ServerId>{}</ServerId></Delete>",
+                xml_escape(server_id)
+            ));
             items_included += 1;
         }
     }
 
     let new_sync_key = Uuid::new_v4().to_string();
-    storage.set_sync_key(owner, state_collection_id, &new_sync_key, Some(&sync_seq_to_token(latest_seq))).await?;
-    let more_available_tag = if more_available { "<MoreAvailable/>" } else { "" };
+    storage
+        .set_sync_key(
+            owner,
+            state_collection_id,
+            &new_sync_key,
+            Some(&sync_seq_to_token(latest_seq)),
+        )
+        .await?;
+    let more_available_tag = if more_available {
+        "<MoreAvailable/>"
+    } else {
+        ""
+    };
 
     Ok(format!(
         r#"<?xml version="1.0" encoding="utf-8"?>

--- a/src/timezone.rs
+++ b/src/timezone.rs
@@ -1,5 +1,5 @@
 // src/timezone.rs
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 
 const TZ_BLOB_LEN: usize = 172;
 
@@ -46,7 +46,8 @@ pub fn eas_timezone_blob_to_iana(b64: &str) -> Option<String> {
     let std_name = read_wchar_name(&bytes, 4);
     let dst_name = read_wchar_name(&bytes, 88);
 
-    if let Some(iana) = windows_name_to_iana(&std_name).or_else(|| windows_name_to_iana(&dst_name)) {
+    if let Some(iana) = windows_name_to_iana(&std_name).or_else(|| windows_name_to_iana(&dst_name))
+    {
         return Some(iana.to_string());
     }
 
@@ -238,36 +239,213 @@ const US_DST: [u8; 16] = [0, 0, 3, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0];
 const US_STD: [u8; 16] = [0, 0, 11, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0];
 const NO_DST: [u8; 16] = [0u8; 16];
 
-type TzParams = (i32, &'static str, &'static str, [u8; 16], [u8; 16], i32, i32);
+type TzParams = (
+    i32,
+    &'static str,
+    &'static str,
+    [u8; 16],
+    [u8; 16],
+    i32,
+    i32,
+);
 
 fn iana_to_windows_params(iana: &str) -> Option<TzParams> {
     Some(match iana {
-        "UTC" | "Etc/UTC" | "Etc/GMT" | "GMT" => (0, "Coordinated Universal Time", "", NO_DST, NO_DST, 0, 0),
-        "Europe/London" => (0, "GMT Standard Time", "GMT Daylight Time", EU_STD, EU_DST, 0, -60),
-        "Europe/Amsterdam" | "Europe/Berlin" | "Europe/Paris" | "Europe/Rome"
-        | "Europe/Madrid" | "Europe/Stockholm" | "Europe/Brussels"
-        | "Europe/Copenhagen" | "Europe/Vienna" | "Europe/Warsaw"
-        | "Europe/Zagreb" | "Europe/Budapest" => (-60, "W. Europe Standard Time", "W. Europe Daylight Time", EU_STD, EU_DST, 0, -60),
-        "Europe/Helsinki" | "Europe/Tallinn" | "Europe/Riga" | "Europe/Vilnius"
-        | "Europe/Kyiv" | "Europe/Bucharest" | "Europe/Athens" | "Europe/Sofia" => (-120, "FLE Standard Time", "FLE Daylight Time", EU_STD, EU_DST, 0, -60),
-        "Europe/Moscow" => (-180, "Russian Standard Time", "Russian Standard Time", NO_DST, NO_DST, 0, 0),
-        "Europe/Istanbul" => (-180, "Turkey Standard Time", "Turkey Standard Time", NO_DST, NO_DST, 0, 0),
-        "Asia/Dubai" => (-240, "Arabian Standard Time", "Arabian Standard Time", NO_DST, NO_DST, 0, 0),
-        "Asia/Kolkata" | "Asia/Calcutta" => (-330, "India Standard Time", "India Standard Time", NO_DST, NO_DST, 0, 0),
-        "Asia/Shanghai" | "Asia/Hong_Kong" => (-480, "China Standard Time", "China Standard Time", NO_DST, NO_DST, 0, 0),
-        "Asia/Singapore" => (-480, "Singapore Standard Time", "Singapore Standard Time", NO_DST, NO_DST, 0, 0),
-        "Asia/Tokyo" => (-540, "Tokyo Standard Time", "Tokyo Standard Time", NO_DST, NO_DST, 0, 0),
-        "Asia/Seoul" => (-540, "Korea Standard Time", "Korea Standard Time", NO_DST, NO_DST, 0, 0),
-        "Australia/Sydney" => (-600, "AUS Eastern Standard Time", "AUS Eastern Daylight Time", NO_DST, EU_DST, 0, -60),
-        "America/New_York" => (300, "Eastern Standard Time", "Eastern Daylight Time", US_STD, US_DST, 0, -60),
-        "America/Chicago" => (360, "Central Standard Time", "Central Daylight Time", US_STD, US_DST, 0, -60),
-        "America/Denver" => (420, "Mountain Standard Time", "Mountain Daylight Time", US_STD, US_DST, 0, -60),
-        "America/Los_Angeles" => (480, "Pacific Standard Time", "Pacific Daylight Time", US_STD, US_DST, 0, -60),
-        "America/Anchorage" => (540, "Alaskan Standard Time", "Alaskan Daylight Time", US_STD, US_DST, 0, -60),
-        "Pacific/Honolulu" => (600, "Hawaiian Standard Time", "Hawaiian Standard Time", NO_DST, NO_DST, 0, 0),
-        "America/Halifax" => (240, "Atlantic Standard Time", "Atlantic Daylight Time", US_STD, US_DST, 0, -60),
-        "America/St_Johns" => (210, "Newfoundland Standard Time", "Newfoundland Daylight Time", US_STD, US_DST, 0, -60),
-        "America/Sao_Paulo" => (180, "E. South America Standard Time", "E. South America Daylight Time", NO_DST, NO_DST, 0, -60),
+        "UTC" | "Etc/UTC" | "Etc/GMT" | "GMT" => {
+            (0, "Coordinated Universal Time", "", NO_DST, NO_DST, 0, 0)
+        }
+        "Europe/London" => (
+            0,
+            "GMT Standard Time",
+            "GMT Daylight Time",
+            EU_STD,
+            EU_DST,
+            0,
+            -60,
+        ),
+        "Europe/Amsterdam" | "Europe/Berlin" | "Europe/Paris" | "Europe/Rome" | "Europe/Madrid"
+        | "Europe/Stockholm" | "Europe/Brussels" | "Europe/Copenhagen" | "Europe/Vienna"
+        | "Europe/Warsaw" | "Europe/Zagreb" | "Europe/Budapest" => (
+            -60,
+            "W. Europe Standard Time",
+            "W. Europe Daylight Time",
+            EU_STD,
+            EU_DST,
+            0,
+            -60,
+        ),
+        "Europe/Helsinki" | "Europe/Tallinn" | "Europe/Riga" | "Europe/Vilnius" | "Europe/Kyiv"
+        | "Europe/Bucharest" | "Europe/Athens" | "Europe/Sofia" => (
+            -120,
+            "FLE Standard Time",
+            "FLE Daylight Time",
+            EU_STD,
+            EU_DST,
+            0,
+            -60,
+        ),
+        "Europe/Moscow" => (
+            -180,
+            "Russian Standard Time",
+            "Russian Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Europe/Istanbul" => (
+            -180,
+            "Turkey Standard Time",
+            "Turkey Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Asia/Dubai" => (
+            -240,
+            "Arabian Standard Time",
+            "Arabian Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Asia/Kolkata" | "Asia/Calcutta" => (
+            -330,
+            "India Standard Time",
+            "India Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Asia/Shanghai" | "Asia/Hong_Kong" => (
+            -480,
+            "China Standard Time",
+            "China Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Asia/Singapore" => (
+            -480,
+            "Singapore Standard Time",
+            "Singapore Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Asia/Tokyo" => (
+            -540,
+            "Tokyo Standard Time",
+            "Tokyo Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Asia/Seoul" => (
+            -540,
+            "Korea Standard Time",
+            "Korea Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "Australia/Sydney" => (
+            -600,
+            "AUS Eastern Standard Time",
+            "AUS Eastern Daylight Time",
+            NO_DST,
+            EU_DST,
+            0,
+            -60,
+        ),
+        "America/New_York" => (
+            300,
+            "Eastern Standard Time",
+            "Eastern Daylight Time",
+            US_STD,
+            US_DST,
+            0,
+            -60,
+        ),
+        "America/Chicago" => (
+            360,
+            "Central Standard Time",
+            "Central Daylight Time",
+            US_STD,
+            US_DST,
+            0,
+            -60,
+        ),
+        "America/Denver" => (
+            420,
+            "Mountain Standard Time",
+            "Mountain Daylight Time",
+            US_STD,
+            US_DST,
+            0,
+            -60,
+        ),
+        "America/Los_Angeles" => (
+            480,
+            "Pacific Standard Time",
+            "Pacific Daylight Time",
+            US_STD,
+            US_DST,
+            0,
+            -60,
+        ),
+        "America/Anchorage" => (
+            540,
+            "Alaskan Standard Time",
+            "Alaskan Daylight Time",
+            US_STD,
+            US_DST,
+            0,
+            -60,
+        ),
+        "Pacific/Honolulu" => (
+            600,
+            "Hawaiian Standard Time",
+            "Hawaiian Standard Time",
+            NO_DST,
+            NO_DST,
+            0,
+            0,
+        ),
+        "America/Halifax" => (
+            240,
+            "Atlantic Standard Time",
+            "Atlantic Daylight Time",
+            US_STD,
+            US_DST,
+            0,
+            -60,
+        ),
+        "America/St_Johns" => (
+            210,
+            "Newfoundland Standard Time",
+            "Newfoundland Daylight Time",
+            US_STD,
+            US_DST,
+            0,
+            -60,
+        ),
+        "America/Sao_Paulo" => (
+            180,
+            "E. South America Standard Time",
+            "E. South America Daylight Time",
+            NO_DST,
+            NO_DST,
+            0,
+            -60,
+        ),
         _ => return None,
     })
 }
@@ -304,7 +482,10 @@ mod tests {
         blob[0..4].copy_from_slice(&480i32.to_le_bytes());
         write_wchar_name(&mut blob, 4, "Pacific Standard Time");
         let b64 = BASE64.encode(blob);
-        assert_eq!(eas_timezone_blob_to_iana(&b64), Some("America/Los_Angeles".to_string()));
+        assert_eq!(
+            eas_timezone_blob_to_iana(&b64),
+            Some("America/Los_Angeles".to_string())
+        );
     }
 
     #[test]
@@ -313,7 +494,10 @@ mod tests {
         blob[0..4].copy_from_slice(&(-120i32).to_le_bytes());
         write_wchar_name(&mut blob, 4, "(UTC+02:00) Custom");
         let b64 = BASE64.encode(blob);
-        assert_eq!(eas_timezone_blob_to_iana(&b64), Some("Etc/GMT-2".to_string()));
+        assert_eq!(
+            eas_timezone_blob_to_iana(&b64),
+            Some("Etc/GMT-2".to_string())
+        );
     }
 
     #[test]

--- a/src/wbxml.rs
+++ b/src/wbxml.rs
@@ -1,6 +1,6 @@
 // src/wbxml.rs
+use anyhow::{Result, anyhow};
 use base64::Engine;
-use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
@@ -12,8 +12,7 @@ const LITERAL: u8 = 0x04;
 const STR_T: u8 = 0x83;
 const OPAQUE: u8 = 0xC3;
 
-static TAG_TO_NAME: LazyLock<HashMap<(u8, u8), &'static str>> =
-    LazyLock::new(build_tag_to_name);
+static TAG_TO_NAME: LazyLock<HashMap<(u8, u8), &'static str>> = LazyLock::new(build_tag_to_name);
 static NAME_TO_TAG: LazyLock<HashMap<&'static str, (u8, u8)>> =
     LazyLock::new(|| TAG_TO_NAME.iter().map(|(&k, &v)| (v, k)).collect());
 
@@ -58,7 +57,7 @@ fn find_encode_tag(qualified_or_local: &str, override_cp: Option<u8>) -> Option<
             return Some(pair);
         }
     }
-    
+
     // Fallback: iterate over TAG_TO_NAME to find all matching entries
     // This is needed because NAME_TO_TAG only holds one entry per tag name,
     // but many tags exist in multiple code pages (e.g., "Status" in cp 0, 6, 7, 8, etc.)
@@ -710,13 +709,14 @@ impl Wbxml {
         }
 
         let mut pos = 0usize;
-        let _version = *bytes.get(pos).ok_or_else(|| anyhow!("Missing WBXML version"))?;
+        let _version = *bytes
+            .get(pos)
+            .ok_or_else(|| anyhow!("Missing WBXML version"))?;
         pos += 1;
         let _public_id = Self::read_mb_uint(bytes, &mut pos)?;
         let _charset = Self::read_mb_uint(bytes, &mut pos)?;
-        let str_table_len =
-            usize::try_from(Self::read_mb_uint(bytes, &mut pos)?)
-                .map_err(|_| anyhow!("Invalid WBXML string table length"))?;
+        let str_table_len = usize::try_from(Self::read_mb_uint(bytes, &mut pos)?)
+            .map_err(|_| anyhow!("Invalid WBXML string table length"))?;
         if pos + str_table_len > bytes.len() {
             return Err(anyhow!("WBXML string table exceeds payload"));
         }
@@ -725,8 +725,7 @@ impl Wbxml {
 
         let mut current_code_page = 0u8;
         let mut xml_stack: Vec<String> = Vec::new();
-        let mut output =
-            String::from("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+        let mut output = String::from("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 
         while pos < bytes.len() {
             let token = bytes[pos];
@@ -750,9 +749,8 @@ impl Wbxml {
                     output.push_str(&xml_escape_text(&content));
                 }
                 STR_T => {
-                    let offset =
-                        usize::try_from(Self::read_mb_uint(bytes, &mut pos)?)
-                            .map_err(|_| anyhow!("Invalid STR_T offset"))?;
+                    let offset = usize::try_from(Self::read_mb_uint(bytes, &mut pos)?)
+                        .map_err(|_| anyhow!("Invalid STR_T offset"))?;
                     if offset >= string_table.len() {
                         return Err(anyhow!("STR_T offset outside string table"));
                     }
@@ -760,8 +758,7 @@ impl Wbxml {
                     while end < string_table.len() && string_table[end] != 0 {
                         end += 1;
                     }
-                    let content =
-                        String::from_utf8(string_table[offset..end].to_vec())?;
+                    let content = String::from_utf8(string_table[offset..end].to_vec())?;
                     output.push_str(&xml_escape_text(&content));
                 }
                 ENTITY => {
@@ -769,17 +766,14 @@ impl Wbxml {
                     output.push_str(&format!("&#{ent};"));
                 }
                 OPAQUE => {
-                    let len =
-                        usize::try_from(Self::read_mb_uint(bytes, &mut pos)?)
-                            .map_err(|_| anyhow!("Invalid OPAQUE length"))?;
+                    let len = usize::try_from(Self::read_mb_uint(bytes, &mut pos)?)
+                        .map_err(|_| anyhow!("Invalid OPAQUE length"))?;
                     if pos + len > bytes.len() {
                         return Err(anyhow!("OPAQUE data exceeds payload"));
                     }
                     let opaque = &bytes[pos..pos + len];
                     pos += len;
-                    output.push_str(
-                        &base64::engine::general_purpose::STANDARD.encode(opaque),
-                    );
+                    output.push_str(&base64::engine::general_purpose::STANDARD.encode(opaque));
                 }
                 LITERAL => {
                     return Err(anyhow!("LITERAL token unsupported in this profile"));
@@ -788,9 +782,7 @@ impl Wbxml {
                     if token >= 0x05 {
                         let has_content = (token & 0x40) != 0;
                         let tag_id = token & 0x3F;
-                        if let Some(name) =
-                            TAG_TO_NAME.get(&(current_code_page, tag_id))
-                        {
+                        if let Some(name) = TAG_TO_NAME.get(&(current_code_page, tag_id)) {
                             output.push_str(&format!("<{name}>"));
                             if has_content {
                                 xml_stack.push(name.to_string());
@@ -804,9 +796,8 @@ impl Wbxml {
                                 tag_id
                             );
                             if has_content {
-                                let placeholder = format!(
-                                    "_unknown_cp{current_code_page}_{tag_id:02x}"
-                                );
+                                let placeholder =
+                                    format!("_unknown_cp{current_code_page}_{tag_id:02x}");
                                 output.push_str(&format!("<{placeholder}>"));
                                 xml_stack.push(placeholder);
                             }
@@ -836,89 +827,111 @@ impl Wbxml {
         loop {
             match reader.read_event_into(&mut event_buf) {
                 Ok(quick_xml::events::Event::Start(ref e)) => {
-            // Extract xmlns:prefix declarations
-            let mut new_prefixes: std::collections::HashMap<String, Option<u8>> = std::collections::HashMap::new();
-            for attr in e.attributes().flatten() {
-                let key_bytes = attr.key.as_ref();
-                if key_bytes.starts_with(b"xmlns:") && key_bytes.len() > 6 {
-                    // XML attribute names are ASCII, so this is safe
-                    let prefix = String::from_utf8_lossy(&key_bytes[6..]);
-                    if let Ok(val) = attr.decode_and_unescape_value(reader.decoder()) {
-                        if let Some(cp) = namespace_to_code_page(val.as_ref()) {
-                            new_prefixes.insert(prefix.into_owned(), Some(cp));
+                    // Extract xmlns:prefix declarations
+                    let mut new_prefixes: std::collections::HashMap<String, Option<u8>> =
+                        std::collections::HashMap::new();
+                    for attr in e.attributes().flatten() {
+                        let key_bytes = attr.key.as_ref();
+                        if key_bytes.starts_with(b"xmlns:") && key_bytes.len() > 6 {
+                            // XML attribute names are ASCII, so this is safe
+                            let prefix = String::from_utf8_lossy(&key_bytes[6..]);
+                            if let Ok(val) = attr.decode_and_unescape_value(reader.decoder())
+                                && let Some(cp) = namespace_to_code_page(val.as_ref())
+                            {
+                                new_prefixes.insert(prefix.into_owned(), Some(cp));
+                            }
                         }
                     }
+                    prefix_ns_stack.push(new_prefixes);
+
+                    let ns_cp = extract_xmlns_cp(e, &reader);
+                    ns_stack.push(ns_cp);
+
+                    // Determine code page from prefix if present
+                    let qname = e.name();
+                    let full_name = String::from_utf8_lossy(qname.as_ref());
+                    let (local_name, effective_cp) = if let Some(pos) = full_name.find(':') {
+                        let prefix = &full_name[..pos];
+                        let local = &full_name[pos + 1..];
+                        let prefix_cp = prefix_ns_stack
+                            .iter()
+                            .rev()
+                            .find_map(|map| map.get(prefix).copied().flatten());
+                        (
+                            local,
+                            prefix_cp
+                                .or(ns_cp)
+                                .or_else(|| ns_stack.iter().rev().find_map(|&x| x)),
+                        )
+                    } else {
+                        (
+                            &*full_name,
+                            ns_cp.or_else(|| ns_stack.iter().rev().find_map(|&x| x)),
+                        )
+                    };
+
+                    self.encode_open_tag(
+                        &mut buf,
+                        &mut current_code_page,
+                        local_name,
+                        effective_cp,
+                        true,
+                    )?;
                 }
-            }
-            prefix_ns_stack.push(new_prefixes);
-            
-            let ns_cp = extract_xmlns_cp(e, &reader);
-            ns_stack.push(ns_cp);
-            
-            // Determine code page from prefix if present
-            let qname = e.name();
-            let full_name = String::from_utf8_lossy(qname.as_ref());
-            let (local_name, effective_cp) = if let Some(pos) = full_name.find(':') {
-                let prefix = &full_name[..pos];
-                let local = &full_name[pos + 1..];
-                let prefix_cp = prefix_ns_stack.iter().rev()
-                    .find_map(|map| map.get(prefix).copied().flatten());
-                (local, prefix_cp.or(ns_cp).or_else(|| ns_stack.iter().rev().find_map(|&x| x)))
-            } else {
-                (&*full_name, ns_cp.or_else(|| ns_stack.iter().rev().find_map(|&x| x)))
-            };
-            
-            self.encode_open_tag(
-                &mut buf,
-                &mut current_code_page,
-                local_name,
-                effective_cp,
-                true,
-            )?;
-        }
                 Ok(quick_xml::events::Event::Empty(ref e)) => {
-            // Extract xmlns:prefix declarations
-            let mut new_prefixes: std::collections::HashMap<String, Option<u8>> = std::collections::HashMap::new();
-            for attr in e.attributes().flatten() {
-                let key_bytes = attr.key.as_ref();
-                if key_bytes.starts_with(b"xmlns:") && key_bytes.len() > 6 {
-                    // XML attribute names are ASCII, so this is safe
-                    let prefix = String::from_utf8_lossy(&key_bytes[6..]);
-                    if let Ok(val) = attr.decode_and_unescape_value(reader.decoder()) {
-                        if let Some(cp) = namespace_to_code_page(val.as_ref()) {
-                            new_prefixes.insert(prefix.into_owned(), Some(cp));
+                    // Extract xmlns:prefix declarations
+                    let mut new_prefixes: std::collections::HashMap<String, Option<u8>> =
+                        std::collections::HashMap::new();
+                    for attr in e.attributes().flatten() {
+                        let key_bytes = attr.key.as_ref();
+                        if key_bytes.starts_with(b"xmlns:") && key_bytes.len() > 6 {
+                            // XML attribute names are ASCII, so this is safe
+                            let prefix = String::from_utf8_lossy(&key_bytes[6..]);
+                            if let Ok(val) = attr.decode_and_unescape_value(reader.decoder())
+                                && let Some(cp) = namespace_to_code_page(val.as_ref())
+                            {
+                                new_prefixes.insert(prefix.into_owned(), Some(cp));
+                            }
                         }
                     }
+                    prefix_ns_stack.push(new_prefixes);
+
+                    let ns_cp = extract_xmlns_cp(e, &reader);
+
+                    // Determine code page from prefix if present
+                    let qname = e.name();
+                    let full_name = String::from_utf8_lossy(qname.as_ref());
+                    let (local_name, effective_cp) = if let Some(pos) = full_name.find(':') {
+                        let prefix = &full_name[..pos];
+                        let local = &full_name[pos + 1..];
+                        let prefix_cp = prefix_ns_stack
+                            .iter()
+                            .rev()
+                            .find_map(|map| map.get(prefix).copied().flatten());
+                        (
+                            local,
+                            prefix_cp
+                                .or(ns_cp)
+                                .or_else(|| ns_stack.iter().rev().find_map(|&x| x)),
+                        )
+                    } else {
+                        (
+                            &*full_name,
+                            ns_cp.or_else(|| ns_stack.iter().rev().find_map(|&x| x)),
+                        )
+                    };
+
+                    self.encode_open_tag(
+                        &mut buf,
+                        &mut current_code_page,
+                        local_name,
+                        effective_cp,
+                        false,
+                    )?;
+
+                    // Pop for Empty elements (they don't have End events)
+                    prefix_ns_stack.pop();
                 }
-            }
-            prefix_ns_stack.push(new_prefixes);
-            
-            let ns_cp = extract_xmlns_cp(e, &reader);
-            
-            // Determine code page from prefix if present
-            let qname = e.name();
-            let full_name = String::from_utf8_lossy(qname.as_ref());
-            let (local_name, effective_cp) = if let Some(pos) = full_name.find(':') {
-                let prefix = &full_name[..pos];
-                let local = &full_name[pos + 1..];
-                let prefix_cp = prefix_ns_stack.iter().rev()
-                    .find_map(|map| map.get(prefix).copied().flatten());
-                (local, prefix_cp.or(ns_cp).or_else(|| ns_stack.iter().rev().find_map(|&x| x)))
-            } else {
-                (&*full_name, ns_cp.or_else(|| ns_stack.iter().rev().find_map(|&x| x)))
-            };
-            
-            self.encode_open_tag(
-                &mut buf,
-                &mut current_code_page,
-                local_name,
-                effective_cp,
-                false,
-            )?;
-            
-            // Pop for Empty elements (they don't have End events)
-            prefix_ns_stack.pop();
-        }
                 Ok(quick_xml::events::Event::Text(ref e)) => {
                     let txt = e
                         .decode()
@@ -931,10 +944,10 @@ impl Wbxml {
                     }
                 }
                 Ok(quick_xml::events::Event::End(_)) => {
-            ns_stack.pop();
-            prefix_ns_stack.pop();
-            buf.push(END);
-        }
+                    ns_stack.pop();
+                    prefix_ns_stack.pop();
+                    buf.push(END);
+                }
                 Ok(quick_xml::events::Event::Eof) => break,
                 Err(e) => return Err(anyhow!("XML encode error: {e:?}")),
                 _ => {}
@@ -967,22 +980,23 @@ impl Wbxml {
     }
 }
 
-fn extract_xmlns_cp<'a, R: std::io::BufRead>(e: &quick_xml::events::BytesStart<'a>, reader: &quick_xml::Reader<R>) -> Option<u8> {
+fn extract_xmlns_cp<'a, R: std::io::BufRead>(
+    e: &quick_xml::events::BytesStart<'a>,
+    reader: &quick_xml::Reader<R>,
+) -> Option<u8> {
     // Only check for default namespace (xmlns). Prefixed namespaces (xmlns:*) are
     // handled separately in the encode function's prefix collection loop.
     // Use direct byte slice comparison to avoid UTF-8 validation and Cow allocation.
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"xmlns" {
-            if let Ok(val) =
-                attr.decode_and_unescape_value(reader.decoder())
-            {
-                if let Some(cp) = namespace_to_code_page(val.as_ref()) {
-                    return Some(cp);
-                }
-                let with_colon = format!("{}:", val);
-                if let Some(cp) = namespace_to_code_page(&with_colon) {
-                    return Some(cp);
-                }
+        if attr.key.as_ref() == b"xmlns"
+            && let Ok(val) = attr.decode_and_unescape_value(reader.decoder())
+        {
+            if let Some(cp) = namespace_to_code_page(val.as_ref()) {
+                return Some(cp);
+            }
+            let with_colon = format!("{}:", val);
+            if let Some(cp) = namespace_to_code_page(&with_colon) {
+                return Some(cp);
             }
         }
     }
@@ -1034,7 +1048,10 @@ mod tests {
         let wb = codec.encode(xml).expect("encode");
         let dec = codec.decode(&wb).expect("decode");
         assert!(dec.contains("<MeetingResponse>"), "decoded: {dec}");
-        assert!(dec.contains("<UserResponse>1</UserResponse>"), "decoded: {dec}");
+        assert!(
+            dec.contains("<UserResponse>1</UserResponse>"),
+            "decoded: {dec}"
+        );
         assert!(dec.contains("<RequestId>abc</RequestId>"), "decoded: {dec}");
     }
 
@@ -1075,7 +1092,10 @@ mod tests {
         let xml = r#"<Ping xmlns="Ping:"><Status>6</Status><MaxFolders>200</MaxFolders></Ping>"#;
         let wb = codec.encode(xml).expect("encode ping");
         let dec = codec.decode(&wb).expect("decode ping");
-        assert!(dec.contains("<MaxFolders>200</MaxFolders>"), "decoded: {dec}");
+        assert!(
+            dec.contains("<MaxFolders>200</MaxFolders>"),
+            "decoded: {dec}"
+        );
     }
 
     #[test]
@@ -1105,7 +1125,10 @@ mod tests {
         let wb = codec.encode(xml).expect("encode location");
         let dec = codec.decode(&wb).expect("decode location");
         assert!(dec.contains("<AirSyncBase:Location>"), "decoded: {dec}");
-        assert!(dec.contains("<AirSyncBase:DisplayName>Conference Room A</AirSyncBase:DisplayName>"), "decoded: {dec}");
+        assert!(
+            dec.contains("<AirSyncBase:DisplayName>Conference Room A</AirSyncBase:DisplayName>"),
+            "decoded: {dec}"
+        );
     }
 
     #[test]
@@ -1123,6 +1146,9 @@ mod tests {
         let xml = r#"<Sync xmlns="AirSync:" xmlns:Calendar="Calendar:"><Collections><Collection><SyncKey>0</SyncKey><CollectionId>1</CollectionId><Commands><Add><ClientId>c1</ClientId><ApplicationData><Calendar:Subject>Test</Calendar:Subject><Calendar:StartTime>2026-03-22T09:00:00Z</Calendar:StartTime><Calendar:EndTime>2026-03-22T10:00:00Z</Calendar:EndTime><Calendar:ClientUid>test-uid-123</Calendar:ClientUid></ApplicationData></Add></Commands></Collection></Collections></Sync>"#;
         let wb = codec.encode(xml).expect("encode");
         let dec = codec.decode(&wb).expect("decode");
-        assert!(dec.contains("<Calendar:ClientUid>test-uid-123</Calendar:ClientUid>"), "decoded: {dec}");
+        assert!(
+            dec.contains("<Calendar:ClientUid>test-uid-123</Calendar:ClientUid>"),
+            "decoded: {dec}"
+        );
     }
 }

--- a/src/wbxml.rs
+++ b/src/wbxml.rs
@@ -848,11 +848,6 @@ impl Wbxml {
                             new_prefixes.insert(prefix.into_owned(), Some(cp));
                         }
                     }
-                    if let Ok(val) = attr.decode_and_unescape_value(reader.decoder()) {
-                        if let Some(cp) = namespace_to_code_page(val.as_ref()) {
-                            new_prefixes.insert(prefix.to_string(), Some(cp));
-                        }
-                    }
                 }
             }
             prefix_ns_stack.push(new_prefixes);
@@ -892,11 +887,6 @@ impl Wbxml {
                     if let Ok(val) = attr.decode_and_unescape_value(reader.decoder()) {
                         if let Some(cp) = namespace_to_code_page(val.as_ref()) {
                             new_prefixes.insert(prefix.into_owned(), Some(cp));
-                        }
-                    }
-                    if let Ok(val) = attr.decode_and_unescape_value(reader.decoder()) {
-                        if let Some(cp) = namespace_to_code_page(val.as_ref()) {
-                            new_prefixes.insert(prefix.to_string(), Some(cp));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

This PR fixes compilation errors (E0382: borrow of moved value) in `src/wbxml.rs` and updates the tokio dependency to the latest version.

## Changes

### 1. Fixed E0382 Borrow-After-Move Errors
- Removed duplicate `if let Ok(val)` blocks in `src/wbxml.rs` (lines 851-855 and 892-896 originally)
- The duplicate blocks caused borrow-after-move errors because:
  - The first block called `prefix.into_owned()` which moves the `prefix` value
  - The second block then attempted to use `prefix.to_string()` which borrows the already-moved value
- The duplicate blocks were unnecessary as they performed the exact same operation

### 2. Updated Dependencies
- Updated `tokio` from version 1.51.0 to 1.51.1 (latest stable per April 2026)

## Testing

- All 73 tests pass (66 unit tests + 7 integration tests)
- Build successful in both debug and release profiles
- Clippy runs with only minor dead code warnings (acceptable for helper functions)

## Related Issues

Fixes the compilation errors reported by CI:
```
error[E0382]: borrow of moved value: `prefix`
 --> src/wbxml.rs:853:49
  |
845 | let prefix = String::from_utf8_lossy(&key_bytes[6..]);
848 | new_prefixes.insert(prefix.into_owned(), Some(cp));
    | ------------ `prefix` moved due to this method call
853 | new_prefixes.insert(prefix.to_string(), Some(cp));
    |                     ^^^^^^ value borrowed here after move
```

---

_This PR was created by an AI assistant (OpenHands) on behalf of the repository owner._

@Voornaamenachternaam can click here to [continue refining the PR](https://app.all-hands.dev/conversations/146dc0fa-ddbd-47ad-8a61-6cb0861dcc26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated `tokio` dependency to version 1.51.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->