### PR TITLE
fix: suppress dead_code warnings for intentionally unused fields

### DIFF
--- a/src/eas.rs
+++ b/src/eas.rs
@@ -89,6 +89,7 @@ struct EasRequest {
     collection_id: Option<String>,
     device_id: Option<String>,
     policy_key: Option<String>,
+    #[allow(dead_code)] // Parsed from MS-ASProtocolVersion header for future protocol negotiation
     protocol_version: Option<String>,
     window_size: Option<usize>,
     get_changes: bool,
@@ -99,6 +100,7 @@ struct EasRequest {
 struct CommandGrammar {
     namespace: &'static str,
     required_tags: &'static [&'static str],
+    #[allow(dead_code)] // Documents allowed optional tags for protocol completeness; validation not currently required
     optional_tags: &'static [&'static str],
 }
 


### PR DESCRIPTION
## Summary
This PR fixes two Clippy `dead_code` warnings in `src/eas.rs` by adding `#[allow(dead_code)]` attributes to fields that are intentionally unused but kept for documentation and potential future use.

## Changes
1. **`protocol_version` field in `EasRequest` struct (line 92)**
   - Added `#[allow(dead_code)]` attribute
   - This field is parsed from the `MS-ASProtocolVersion` header
   - May be needed for future protocol version negotiation

2. **`optional_tags` field in `CommandGrammar` struct (line 102)**
   - Added `#[allow(dead_code)]` attribute
   - Documents allowed optional tags for each EAS command
   - Validation of optional tags is not currently required

## Warnings Fixed
```
warning: field `protocol_version` is never read
 --> src/eas.rs:92:5

warning: field `optional_tags` is never read
 --> src/eas.rs:102:5
```

## Rationale
Both fields are intentionally kept in the code because:
- They document the EAS (Exchange ActiveSync) protocol specification completely
- The `protocol_version` may be needed for protocol version negotiation in future versions
- The `optional_tags` field helps developers understand what tags are valid for each command

## Testing
- The changes suppress the warnings while preserving the protocol documentation
- No functional changes to the codebase

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure updates to the request and command processing layers to support enhanced protocol version handling and command grammar documentation. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->