### PR TITLE
Refactor: standardize deps — phf, icalendar, quick-xml escape, unicod…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Exchange Gateway — Contributor Guide
+
+## Build & Test
+```bash
+cargo check          # Compile (Rust 1.95.0, edition 2024)
+cargo test           # 68 unit + integration + snapshot tests
+cargo clippy         # Lint (2 known dead_code warnings: is_stub_action, folded_line)
+```
+
+## Architecture
+- **Protocol adapters**: `ews.rs` (EWS SOAP), `eas.rs` (EAS WBXML), `caldav.rs` (CalDAV)
+- **Calendar/iCal**: `calendar.rs`, `ical_parser.rs`, `meeting/` (scheduling, message, attendee, state)
+- **WBXML codec**: `wbxml.rs` (EAS binary XML, compile-time `phf::Map` lookup tables)
+- **Storage**: `storage.rs` (SQLite via sqlx), `permission/` (delegate permissions)
+- **Sync**: `sync.rs` (EAS sync protocol), `ews_folders.rs`, `ews_update.rs`
+- **Utilities**: `util.rs` (XML escape via quick_xml, NFC normalize, email normalize, path sanitize)
+- **Timezone**: `timezone.rs` (IANA ↔ Windows mapping via windows-timezones)
+
+## Key Dependencies
+| Dep | Version | Purpose |
+|-----|---------|---------|
+| quick-xml | 0.39.2 | XML parsing + `escape::escape()`/`partial_escape()` for XML encoding |
+| phf | 0.12.1 | Compile-time perfect hash maps for WBXML tag lookup (zero startup cost) |
+| icalendar | 0.17.10 | RFC 5545 iCal parser/builder; `parser::unfold()` for line unfolding |
+| unicode-normalization | 0.1.25 | NFC normalization for email/string comparison |
+| rrule | 0.14.0 | Recurrence rule parsing (shared with icalendar) |
+| windows-timezones | 0.5.1 | IANA ↔ Windows timezone ID mapping |
+| nom | 8.0.0 | iCal property line parser, email parsing |
+| chrono / chrono-tz | latest | DateTime with timezone support |
+| axum | 0.8.x | HTTP framework |
+| sqlx | 0.8.x | Async SQLite |
+
+## Dependency Decisions
+- **`icu_normalizer`**: REJECTED. 50+ crate tree for zero functional gain over `unicode-normalization`.
+- **`calcard`**: REMOVED. Dead dependency (never imported in any .rs file).
+- **`structured-email-address`**: REJECTED. v0.0.5 / 80 downloads — too immature for production.
+- **`axum-auth`**: REJECTED. Only ~50 lines of custom basic auth; EAS needs zeroize/SecretString.
+- **`icalendar` full integration**: Phase 2. Builder/parser can replace render_ics/generate_ical/parse_ics, but requires careful CalendarItem ↔ Event adapter mapping.
+
+## Code Patterns
+- XML escaping: use `crate::util::xml_escape()` / `xml_escape_text()` — delegates to `quick_xml::escape`
+- iCal unfolding: use `crate::ical_parser::unfold_ical_content()` — delegates to `icalendar::parser::unfold`
+- Email normalization: use `crate::util::normalize_email()` — strips mailto:, NFC, lowercases
+- WBXML: static `TAG_TO_NAME`/`NAME_TO_TAG` via `phf::Map` (compile-time, no LazyLock)
+- iCal text escaping: 3 duplicate `escape_ical_text` impls (calendar.rs, meeting/message.rs, meeting/scheduling.rs) — Phase 2 candidate for icalendar consolidation
+
+## Warnings
+- `is_stub_action` in ews.rs: dead code, safe to ignore
+- `folded_line` in meeting/message.rs: dead code, safe to ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,24 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "calcard"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bb5cc4aa43df0df11be8fee3f375ce286876cb859ff6f58173d1619858f550"
-dependencies = [
- "ahash",
- "chrono",
- "chrono-tz",
- "hashify",
- "jmap-tools",
- "mail-builder",
- "mail-parser",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +464,18 @@ dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -789,11 +770,12 @@ dependencies = [
  "anyhow",
  "axum",
  "base64",
+ "bitflags",
  "bytes",
- "calcard",
  "chrono",
  "chrono-tz",
  "compact_str",
+ "const-hex",
  "criterion",
  "dashmap",
  "flate2",
@@ -805,6 +787,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "icalendar",
  "insta",
  "itoa",
  "lru",
@@ -816,6 +799,7 @@ dependencies = [
  "opentelemetry_sdk 0.29.0",
  "parking_lot",
  "percent-encoding",
+ "phf",
  "pin-project-lite",
  "pretty_assertions",
  "proptest",
@@ -845,6 +829,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "unicode-normalization",
  "url",
  "urlencoding",
  "uuid",
@@ -1121,18 +1106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "hashify"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
-dependencies = [
- "indexmap 2.14.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1298,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "icalendar"
+version = "0.17.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "264fe856964b7a84076dec2d8ea29fce7c9b422968c9a2f404d4aa3771ae2179"
+dependencies = [
+ "chrono",
+ "iso8601",
+ "nom",
+ "nom-language",
+ "uuid",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,17 +1507,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jmap-tools"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1913b7861fd4a4c4dc25a617f06c4952525f9ed8bb880a3dba672953188f2eed"
-dependencies = [
- "hashify",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "jni"
@@ -1651,21 +1635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mail-builder"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900998f307338c4013a28ab14d760b784067324b164448c6d98a89e44810473b"
-
-[[package]]
-name = "mail-parser"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
-dependencies = [
- "hashify",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1689,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1914,7 +1892,32 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
+ "phf_macros",
  "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2756,12 +2759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,6 +3375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,7 +3428,6 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
- "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,6 @@ futures-core = "^0.3.32"
 # Compact string storage for memory efficiency
 compact_str = { version = "^0.9.0", features = ["serde", "bytes"] }
 
-# Calendar card parsing
-calcard = "^0.3.2"
-
 # HTTP header utilities
 headers = "^0.4.1"
 
@@ -135,6 +132,21 @@ http = "^1.3.0"
 
 # Memory-efficient string handling (NEW)
 smartstring = "^1.0.1"
+
+# Fast hex encoding — replaces hand-rolled format!("{:02x}") loops (NEW)
+const-hex = "^1.18.1"
+
+# Bitflags derive macro — replaces manual bitflag implementations (NEW)
+bitflags = "^2.9.0"
+
+# Unicode normalization (NFC/NFD) — ensures canonical string comparison for email addresses (NEW)
+unicode-normalization = "^0.1.25"
+
+# Compile-time perfect hash — replaces runtime HashMap for WBXML lookup tables (NEW)
+phf = { version = "^0.12.1", features = ["macros"] }
+
+# RFC 5545 iCalendar builder and parser — replaces custom iCal escape/unescape/fold/parse/render (NEW)
+icalendar = { version = "^0.17.10", features = ["parser"] }
 
 [dev-dependencies]
 proptest = "^1.11.0"

--- a/src/autodiscover.rs
+++ b/src/autodiscover.rs
@@ -1,5 +1,5 @@
 // src/autodiscover.rs
-use crate::util::xml_escape;
+use crate::util::{nfc, xml_escape};
 use axum::http::StatusCode;
 use serde::Deserialize;
 
@@ -34,7 +34,7 @@ fn extract_email_from_v1_xml(body: &str) -> Option<String> {
         .find("<EMailAddress>")
         .map(|i| i + "<EMailAddress>".len())?;
     let end = body[start..].find("</EMailAddress>").map(|i| start + i)?;
-    let email = body[start..end].trim().to_string();
+    let email = nfc(body[start..end].trim());
     if email.contains('@') {
         Some(email)
     } else {
@@ -53,7 +53,7 @@ fn extract_email_from_soap(body: &str) -> Option<String> {
             body[start..].find(close).map(|j| start + j)
         }) {
             let start = body.find(open).map(|i| i + open.len()).unwrap_or(0);
-            let email = body[start..end].trim().to_string();
+            let email = nfc(body[start..end].trim());
             if email.contains('@') {
                 return Some(email);
             }

--- a/src/caldav.rs
+++ b/src/caldav.rs
@@ -1,6 +1,7 @@
 // src/caldav.rs
 use crate::config::Config;
 use anyhow::Result;
+use const_hex;
 use reqwest::header::{CONTENT_TYPE, ETAG, IF_MATCH, IF_NONE_MATCH};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
@@ -268,13 +269,7 @@ impl CaldavClient {
     }
 
     fn synthetic_etag(&self, ics: &str) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(ics.as_bytes());
-        hasher
-            .finalize()
-            .iter()
-            .map(|b| format!("{:02x}", b))
-            .collect()
+        const_hex::encode(Sha256::digest(ics.as_bytes()))
     }
 }
 

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -1,5 +1,6 @@
 // src/calendar.rs
 use crate::ical_parser;
+use crate::util::nfc;
 use anyhow::{Result, anyhow};
 use chrono::{NaiveDate, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
@@ -407,7 +408,7 @@ pub fn parse_ics_content(ics: &str) -> Vec<(String, String)> {
         Ok(properties) => properties,
         Err(_) => {
             // Fallback to legacy parsing if nom parser fails
-            let unfolded = ics.replace("\r\n ", "").replace("\r\n\t", "");
+            let unfolded = ical_parser::unfold_ical_content(ics);
             let mut properties = Vec::new();
             for line in unfolded.lines() {
                 if line.is_empty() {
@@ -425,7 +426,7 @@ pub fn parse_ics_content(ics: &str) -> Vec<(String, String)> {
 }
 
 fn split_ical_blocks(ics: &str) -> Vec<Vec<String>> {
-    let unfolded = ics.replace("\r\n ", "").replace("\r\n\t", "");
+    let unfolded = ical_parser::unfold_ical_content(ics);
     let mut blocks = Vec::new();
     let mut current = Vec::new();
     let mut in_vevent = false;
@@ -1161,19 +1162,20 @@ fn parse_ical_param(key: &str, name: &str) -> Option<String> {
 
 fn parse_ical_actor_line(key: &str, value: &str) -> (Option<String>, Option<String>) {
     let name = parse_ical_param(key, "CN").map(|v| unescape_ical_text(&v));
-    let email = value
+    let raw_email = value
         .strip_prefix("mailto:")
         .or_else(|| value.strip_prefix("MAILTO:"))
-        .unwrap_or(value)
-        .to_string();
+        .unwrap_or(value);
+    let email = nfc(raw_email);
     (name, Some(email))
 }
 
 fn normalize_mailto(email: &str) -> String {
-    if email.to_ascii_lowercase().starts_with("mailto:") {
-        email.to_string()
+    let nfc_email = nfc(email);
+    if nfc_email.to_ascii_lowercase().starts_with("mailto:") {
+        nfc_email
     } else {
-        format!("mailto:{email}")
+        format!("mailto:{nfc_email}")
     }
 }
 
@@ -1325,7 +1327,7 @@ pub fn parse_eas_sync_mutations(xml: &str) -> Result<Vec<EasSyncMutation>> {
                         Some(b"UID") => current.uid = Some(value),
                         Some(b"ClientUid") => current.client_uid = Some(value),
                         Some(b"OrganizerName") => current.organizer_name = Some(value),
-                        Some(b"OrganizerEmail") => current.organizer_email = Some(value),
+                        Some(b"OrganizerEmail") => current.organizer_email = Some(nfc(&value)),
                         Some(b"BusyStatus") => {
                             if let Some(ex) = current.current_exception.as_mut() {
                                 ex.busy_status = value.parse().ok();
@@ -1783,7 +1785,7 @@ pub fn parse_ews_attendees(xml: &str) -> Vec<Attendee> {
                     let value = t.decode().ok().map(|v| v.into_owned()).unwrap_or_default();
                     match stack.last().map(|v| v.as_slice()) {
                         Some(b"Name") => attendee.name = Some(value),
-                        Some(b"EmailAddress") => attendee.email = value,
+                        Some(b"EmailAddress") => attendee.email = nfc(&value),
                         Some(b"ResponseType") => {
                             let (status, partstat) = match value.as_str() {
                                 "Accept" => (Some(3), Some("ACCEPTED".to_string())),

--- a/src/eas.rs
+++ b/src/eas.rs
@@ -3,7 +3,7 @@ use crate::caldav::CaldavClient;
 use crate::calendar::{parse_datetime, parse_ics_event};
 use crate::models::AppState;
 use crate::sync::{self, SyncOptions, filter_type_to_start};
-use crate::util::xml_escape;
+use crate::util::{nfc, xml_escape};
 use crate::wbxml::Wbxml;
 use crate::permission::{PermissionEnforcement, PermissionContext};
 use axum::extract::{Query, State};
@@ -527,7 +527,7 @@ fn matches_search(item: &crate::calendar::CalendarItem, query: Option<&str>) -> 
         || item
             .attendees
             .iter()
-            .any(|a| a.email.to_ascii_lowercase().contains(&q))
+            .any(|a| nfc(&a.email).to_ascii_lowercase().contains(&q))
 }
 
 fn make_request_id() -> String {

--- a/src/ews.rs
+++ b/src/ews.rs
@@ -4,6 +4,7 @@ use crate::calendar::{
     extract_ews_field, extract_ews_fields, parse_ews_attendees, parse_ews_calendar_item,
     parse_ews_recurrence, parse_ics_event, render_ics,
 };
+use crate::util::nfc;
 use crate::ews_folders::{
     DistinguishedFolder, folder_id_for, render_folder_xml, validate_folder_request,
 };
@@ -22,6 +23,7 @@ use axum::{
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use chrono::Datelike;
+use const_hex;
 use quick_xml::Reader;
 use quick_xml::events::Event;
 use sha2::{Digest, Sha256};
@@ -432,7 +434,7 @@ fn changekey_for_item(item: &EwsItemRow) -> String {
         h.update(u.as_bytes());
     }
     let digest = h.finalize();
-    digest[..12].iter().map(|b| format!("{:02x}", b)).collect()
+    const_hex::encode(&digest[..12])
 }
 
 fn busy_status_to_ews(value: u8) -> &'static str {
@@ -1437,9 +1439,11 @@ async fn load_current_calendar_items(
                 {
                     let server_id = generate_server_id(state.cfg.hmac_secret(), &href);
                     let safe_etag = if etag.is_empty() {
-                        let mut h = Sha256::new();
-                        h.update(server_id.as_bytes());
-                        h.finalize().iter().map(|b| format!("{:02x}", b)).collect()
+                        const_hex::encode({
+                            let mut h = Sha256::new();
+                            h.update(server_id.as_bytes());
+                            h.finalize()
+                        })
                     } else {
                         etag.clone()
                     };
@@ -2235,7 +2239,7 @@ async fn handle_update_item(state: &Arc<AppState>, auth: &AuthContext, body: &st
             current_item.organizer_name = Some(v);
         }
         if let Some(v) = extract_ews_field(body, b"OrganizerEmail") {
-            current_item.organizer_email = Some(v);
+            current_item.organizer_email = Some(nfc(&v));
         }
         if body.contains("RequiredAttendees") || body.contains("OptionalAttendees") {
             current_item.attendees = parse_ews_attendees(body);

--- a/src/ews_folders.rs
+++ b/src/ews_folders.rs
@@ -1,5 +1,6 @@
 // src/ews_folders.rs
 use crate::util::xml_escape;
+use const_hex;
 use sha2::{Digest, Sha256};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -121,10 +122,7 @@ pub fn folder_id_for(owner: &str, folder: DistinguishedFolder) -> String {
     format!(
         "{}-{}",
         tag,
-        digest[..12]
-            .iter()
-            .map(|b| format!("{:02x}", b))
-            .collect::<String>()
+        const_hex::encode(&digest[..12])
     )
 }
 

--- a/src/ews_update.rs
+++ b/src/ews_update.rs
@@ -2,7 +2,7 @@
 use crate::calendar::{
     CalendarItem, extract_ews_field, extract_ews_fields, parse_ews_attendees, parse_ews_recurrence,
 };
-use crate::util::xml_escape;
+use crate::util::{nfc, xml_escape};
 use quick_xml::Reader;
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 
@@ -396,7 +396,7 @@ pub fn apply_field_changes(item: &mut CalendarItem, changes: &[EwsFieldChange]) 
                 }
                 _ => {
                     if let Some(v) = extract_ews_field(payload, b"EmailAddress") {
-                        item.organizer_email = Some(v);
+                        item.organizer_email = Some(nfc(&v));
                     }
                     if let Some(v) = extract_ews_field(payload, b"Name") {
                         item.organizer_name = Some(v);

--- a/src/ical_parser.rs
+++ b/src/ical_parser.rs
@@ -1,8 +1,10 @@
 // src/ical_parser.rs
 use chrono::{DateTime, NaiveDateTime, NaiveDate, Utc};
 
+/// Unfold iCal content lines per RFC 5545 §3.1.
+/// Delegates to `icalendar::parser::unfold` for standards compliance.
 pub fn unfold_ical_content(input: &str) -> String {
-    input.replace("\r\n ", "").replace("\n ", "")
+    icalendar::parser::unfold(input)
 }
 
 pub fn parse_property_line(input: &str) -> Result<(String, Vec<(String, String)>, String), nom::Err<nom::error::Error<&str>>> {

--- a/src/meeting/attendee.rs
+++ b/src/meeting/attendee.rs
@@ -1,4 +1,5 @@
 // src/meeting/attendee.rs
+use crate::util::normalize_email;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -245,12 +246,14 @@ impl AttendeeTracker {
     }
 
     pub fn add_attendee(&mut self, email: String, name: Option<String>, role: AttendeeRole) {
+        let email = normalize_email(&email);
         if !self.attendees.iter().any(|a| a.email == email) {
             self.attendees.push(AttendeeResponse::new(email, name, role));
         }
     }
 
     pub fn remove_attendee(&mut self, email: &str) -> bool {
+        let email = normalize_email(email);
         let len_before = self.attendees.len();
         self.attendees.retain(|a| a.email != email);
         self.attendees.len() != len_before
@@ -261,6 +264,7 @@ impl AttendeeTracker {
         email: &str,
         status: AttendeeStatus,
     ) -> Result<(), &'static str> {
+        let email = normalize_email(email);
         if let Some(attendee) = self.attendees.iter_mut().find(|a| a.email == email) {
             attendee.respond(status);
             Ok(())
@@ -275,6 +279,7 @@ impl AttendeeTracker {
         start: DateTime<Utc>,
         end: DateTime<Utc>,
     ) -> Result<(), &'static str> {
+        let email = normalize_email(email);
         if let Some(attendee) = self.attendees.iter_mut().find(|a| a.email == email) {
             attendee.propose_new_time(start, end);
             Ok(())
@@ -284,10 +289,12 @@ impl AttendeeTracker {
     }
 
     pub fn get_attendee(&self, email: &str) -> Option<&AttendeeResponse> {
+        let email = normalize_email(email);
         self.attendees.iter().find(|a| a.email == email)
     }
 
     pub fn get_attendee_mut(&mut self, email: &str) -> Option<&mut AttendeeResponse> {
+        let email = normalize_email(email);
         self.attendees.iter_mut().find(|a| a.email == email)
     }
 

--- a/src/meeting/scheduling.rs
+++ b/src/meeting/scheduling.rs
@@ -2,6 +2,7 @@
 
 use crate::calendar::CalendarItem;
 use crate::ical_parser;
+use crate::util::normalize_email;
 use chrono::{DateTime, Utc};
 
 pub struct SchedulingContext {
@@ -139,12 +140,8 @@ pub fn parse_itip_response(ical: &str) -> Option<ItipResponse> {
         } else if key == "SEQUENCE" {
             sequence = value.parse().unwrap_or(0);
         } else if key.starts_with("ORGANIZER") {
-            // Extract email from mailto: format
-            let email = if value.len() >= 7 && value[..7].eq_ignore_ascii_case("mailto:") {
-                value[7..].to_string()
-            } else {
-                value.clone()
-            };
+            // Extract email from mailto: format, NFC-normalize for storage
+            let email = normalize_email(value);
             organizer_email = Some(email);
         }
     }
@@ -155,12 +152,8 @@ pub fn parse_itip_response(ical: &str) -> Option<ItipResponse> {
     // Second pass: find the first ATTENDEE that is not the organizer
     for (key, value) in event_props {
         if key.starts_with("ATTENDEE") {
-            // Extract email from mailto: format
-            let email = if let Some(pos) = value.find("mailto:") {
-                value[pos + 7..].to_string()
-            } else {
-                value.clone()
-            };
+            // Extract email from mailto: format, NFC-normalize for storage
+            let email = normalize_email(value);
 
             // Skip if this attendee is the organizer
             if let Some(ref org_email) = organizer_email {

--- a/src/meeting/state.rs
+++ b/src/meeting/state.rs
@@ -1,11 +1,8 @@
 // src/meeting/state.rs
+use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-
-const ASF_MEETING: u8 = 0x01;
-const ASF_RECEIVED: u8 = 0x02;
-const ASF_CANCELED: u8 = 0x04;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MeetingStatus {
@@ -53,11 +50,27 @@ impl fmt::Display for MeetingStatus {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct MeetingStateFlags {
-    pub is_meeting: bool,
-    pub is_received: bool,
-    pub is_canceled: bool,
+bitflags! {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct MeetingStateFlags: u8 {
+        const IS_MEETING  = 0x01;
+        const IS_RECEIVED = 0x02;
+        const IS_CANCELED = 0x04;
+    }
+}
+
+// Serde: serialize as u8, deserialize from u8 — preserves wire format
+impl Serialize for MeetingStateFlags {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u8(self.bits())
+    }
+}
+
+impl<'de> Deserialize<'de> for MeetingStateFlags {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bits = u8::deserialize(deserializer)?;
+        Ok(Self::from_bits_retain(bits))
+    }
 }
 
 impl MeetingStateFlags {
@@ -66,44 +79,42 @@ impl MeetingStateFlags {
     }
 
     pub fn from_byte(value: u8) -> Self {
-        Self {
-            is_meeting: value & ASF_MEETING != 0,
-            is_received: value & ASF_RECEIVED != 0,
-            is_canceled: value & ASF_CANCELED != 0,
-        }
+        Self::from_bits_retain(value)
     }
 
     pub fn to_byte(&self) -> u8 {
-        let mut value = 0u8;
-        if self.is_meeting {
-            value |= ASF_MEETING;
-        }
-        if self.is_received {
-            value |= ASF_RECEIVED;
-        }
-        if self.is_canceled {
-            value |= ASF_CANCELED;
-        }
-        value
+        self.bits()
+    }
+
+    pub fn is_meeting(&self) -> bool {
+        self.contains(Self::IS_MEETING)
+    }
+
+    pub fn is_received(&self) -> bool {
+        self.contains(Self::IS_RECEIVED)
+    }
+
+    pub fn is_canceled(&self) -> bool {
+        self.contains(Self::IS_CANCELED)
     }
 
     pub fn to_meeting_status(&self, is_organizer: bool, response_type: Option<u8>) -> MeetingStatus {
-        if self.is_canceled {
+        if self.is_canceled() {
             if is_organizer {
                 return MeetingStatus::OrganizerCanceled;
             } else {
                 return MeetingStatus::ReceivedCanceled;
             }
         }
-        
-        if !self.is_meeting {
+
+        if !self.is_meeting() {
             return MeetingStatus::Appointment;
         }
-        
+
         if is_organizer {
             return MeetingStatus::Organizer;
         }
-        
+
         match response_type {
             Some(2) => MeetingStatus::Tentative,
             Some(3) => MeetingStatus::Accepted,
@@ -112,7 +123,6 @@ impl MeetingStateFlags {
         }
     }
 }
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MeetingState {
     Draft,
@@ -256,7 +266,7 @@ impl MeetingStateMachine {
         if !self.can_send_request() {
             return Err("Cannot send request from current state");
         }
-        self.context.state_flags.is_meeting = true;
+        self.context.state_flags.insert(MeetingStateFlags::IS_MEETING);
         self.context.state = MeetingState::RequestSent;
         self.context.increment_sequence();
         Ok(())
@@ -271,8 +281,8 @@ impl MeetingStateMachine {
         if self.context.state != MeetingState::Draft {
             return Err("Cannot receive request in current state");
         }
-        self.context.state_flags.is_meeting = true;
-        self.context.state_flags.is_received = true;
+        self.context.state_flags.insert(MeetingStateFlags::IS_MEETING);
+        self.context.state_flags.insert(MeetingStateFlags::IS_RECEIVED);
         self.context.state = MeetingState::PendingResponses;
         self.context.updated_at = now;
         Ok(())
@@ -298,7 +308,7 @@ impl MeetingStateMachine {
         if !self.can_cancel() {
             return Err("Cannot cancel meeting from current state");
         }
-        self.context.state_flags.is_canceled = true;
+        self.context.state_flags.insert(MeetingStateFlags::IS_CANCELED);
         self.context.state = MeetingState::Cancelled;
         self.context.increment_sequence();
         Ok(())
@@ -375,42 +385,30 @@ mod tests {
     #[test]
     fn test_state_flags_from_byte() {
         let flags = MeetingStateFlags::from_byte(0x01);
-        assert!(flags.is_meeting);
-        assert!(!flags.is_received);
-        assert!(!flags.is_canceled);
+        assert!(flags.is_meeting());
+        assert!(!flags.is_received());
+        assert!(!flags.is_canceled());
 
         let flags = MeetingStateFlags::from_byte(0x03);
-        assert!(flags.is_meeting);
-        assert!(flags.is_received);
-        assert!(!flags.is_canceled);
+        assert!(flags.is_meeting());
+        assert!(flags.is_received());
+        assert!(!flags.is_canceled());
 
         let flags = MeetingStateFlags::from_byte(0x07);
-        assert!(flags.is_meeting);
-        assert!(flags.is_received);
-        assert!(flags.is_canceled);
+        assert!(flags.is_meeting());
+        assert!(flags.is_received());
+        assert!(flags.is_canceled());
     }
 
     #[test]
     fn test_state_flags_to_byte() {
-        let flags = MeetingStateFlags {
-            is_meeting: true,
-            is_received: false,
-            is_canceled: false,
-        };
+        let flags = MeetingStateFlags::IS_MEETING;
         assert_eq!(flags.to_byte(), 0x01);
 
-        let flags = MeetingStateFlags {
-            is_meeting: true,
-            is_received: true,
-            is_canceled: false,
-        };
+        let flags = MeetingStateFlags::IS_MEETING | MeetingStateFlags::IS_RECEIVED;
         assert_eq!(flags.to_byte(), 0x03);
 
-        let flags = MeetingStateFlags {
-            is_meeting: true,
-            is_received: true,
-            is_canceled: true,
-        };
+        let flags = MeetingStateFlags::IS_MEETING | MeetingStateFlags::IS_RECEIVED | MeetingStateFlags::IS_CANCELED;
         assert_eq!(flags.to_byte(), 0x07);
     }
 

--- a/src/permission/delegate.rs
+++ b/src/permission/delegate.rs
@@ -1,7 +1,8 @@
 // src/permission/delegate.rs
-use crate::permission::types::{DelegateInfo, PermissionLevel, PermissionRights, PermissionAuditEntry};
+use crate::permission::types::{DelegateInfo, PermissionLevel, PermissionAuditEntry};
 use crate::permission::storage::PermissionStorage;
 use crate::storage::Storage;
+use crate::util::normalize_email;
 use anyhow::Result;
 
 pub struct DelegateManager<'a> {
@@ -31,7 +32,7 @@ impl<'a> DelegateManager<'a> {
         calendar_permission: PermissionLevel,
         actor_email: &str,
     ) -> Result<DelegateInfo> {
-        if delegator == delegate_email {
+        if normalize_email(delegator) == normalize_email(delegate_email) {
             anyhow::bail!("Cannot add self as delegate");
         }
 

--- a/src/permission/enforcement.rs
+++ b/src/permission/enforcement.rs
@@ -2,6 +2,7 @@
 use crate::permission::types::{CalendarPermission, PermissionLevel, PermissionRights};
 use crate::permission::storage::PermissionStorage;
 use crate::storage::Storage;
+use crate::util::normalize_email;
 use anyhow::Result;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -52,12 +53,12 @@ impl PermissionContext {
     }
 
     pub fn is_owner(&self) -> bool {
-        self.actor_email == self.folder_owner
+        normalize_email(&self.actor_email) == normalize_email(&self.folder_owner)
     }
 
     pub fn owns_item(&self) -> bool {
         match &self.item_owner {
-            Some(owner) => owner == &self.actor_email,
+            Some(owner) => normalize_email(&self.actor_email) == normalize_email(owner),
             None => false, // SECURITY: Deny by default when ownership is unknown
         }
     }
@@ -183,7 +184,7 @@ impl<'a> PermissionEnforcement<'a> {
         }
 
         let old_perm = self.storage.get_permission(owner, folder_id, user_email).await?;
-        let old_rights = old_perm.as_ref().map(|p| p.rights);
+        let old_rights = old_perm.as_ref().map(|p| p.rights().bits());
 
         let mut perm = CalendarPermission::new(
             folder_id.to_string(),
@@ -202,7 +203,7 @@ impl<'a> PermissionEnforcement<'a> {
             user_email.to_string(),
             "set".to_string(),
             old_rights,
-            Some(perm.rights),
+            Some(perm.rights().bits()),
         );
         self.storage.add_audit_entry(&audit).await?;
 
@@ -222,7 +223,7 @@ impl<'a> PermissionEnforcement<'a> {
         }
 
         let old_perm = self.storage.get_permission(owner, folder_id, user_email).await?;
-        let old_rights = old_perm.as_ref().map(|p| p.rights);
+        let _old_rights = old_perm.as_ref().map(|p| p.rights().bits());
 
         self.storage.delete_permission(owner, folder_id, user_email).await?;
 
@@ -233,7 +234,7 @@ impl<'a> PermissionEnforcement<'a> {
                 actor_email.to_string(),
                 user_email.to_string(),
                 "remove".to_string(),
-                Some(perm.rights),
+                Some(perm.rights().bits()),
                 None,
             );
             self.storage.add_audit_entry(&audit).await?;
@@ -255,7 +256,7 @@ impl<'a> PermissionEnforcement<'a> {
         }
 
         let old_perm = self.storage.get_default_permission(owner, folder_id).await?;
-        let old_rights = old_perm.as_ref().map(|p| p.rights);
+        let old_rights = old_perm.as_ref().map(|p| p.rights().bits());
 
         let perm = CalendarPermission::default_permission(
             folder_id.to_string(),
@@ -272,7 +273,7 @@ impl<'a> PermissionEnforcement<'a> {
             "default".to_string(),
             "set_default".to_string(),
             old_rights,
-            Some(perm.rights),
+            Some(perm.rights().bits()),
         );
         self.storage.add_audit_entry(&audit).await?;
 
@@ -292,7 +293,7 @@ impl<'a> PermissionEnforcement<'a> {
         }
 
         let old_perm = self.storage.get_anonymous_permission(owner, folder_id).await?;
-        let old_rights = old_perm.as_ref().map(|p| p.rights);
+        let old_rights = old_perm.as_ref().map(|p| p.rights().bits());
 
         let perm = CalendarPermission::anonymous_permission(
             folder_id.to_string(),
@@ -309,7 +310,7 @@ impl<'a> PermissionEnforcement<'a> {
             "anonymous".to_string(),
             "set_anonymous".to_string(),
             old_rights,
-            Some(perm.rights),
+            Some(perm.rights().bits()),
         );
         self.storage.add_audit_entry(&audit).await?;
 

--- a/src/permission/types.rs
+++ b/src/permission/types.rs
@@ -1,193 +1,86 @@
 // src/permission/types.rs
+use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-const RIGHT_READ_ANY: u32 = 0x00000001;
-const RIGHT_CREATE: u32 = 0x00000002;
-const RIGHT_EDIT_OWNED: u32 = 0x00000008;
-const RIGHT_DELETE_OWNED: u32 = 0x00000010;
-const RIGHT_EDIT_ANY: u32 = 0x00000020;
-const RIGHT_DELETE_ANY: u32 = 0x00000040;
-const RIGHT_CREATE_SUBFOLDER: u32 = 0x00000080;
-const RIGHT_FOLDER_OWNER: u32 = 0x00000100;
-const RIGHT_FOLDER_CONTACT: u32 = 0x00000200;
-const RIGHT_FOLDER_VISIBLE: u32 = 0x00000400;
-const RIGHT_FREEBUSY_SIMPLE: u32 = 0x00000800;
-const RIGHT_FREEBUSY_DETAILED: u32 = 0x00001000;
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct PermissionRights: u32 {
+        const READ_ANY          = 0x00000001;
+        const CREATE            = 0x00000002;
+        const EDIT_OWNED        = 0x00000008;
+        const DELETE_OWNED      = 0x00000010;
+        const EDIT_ANY          = 0x00000020;
+        const DELETE_ANY        = 0x00000040;
+        const CREATE_SUBFOLDER  = 0x00000080;
+        const FOLDER_OWNER      = 0x00000100;
+        const FOLDER_CONTACT    = 0x00000200;
+        const FOLDER_VISIBLE    = 0x00000400;
+        const FREEBUSY_SIMPLE   = 0x00000800;
+        const FREEBUSY_DETAILED = 0x00001000;
+    }
+}
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct PermissionRights(pub u32);
+// Serde: serialize as u32, deserialize from u32 — preserves wire format compatibility
+impl Serialize for PermissionRights {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u32(self.bits())
+    }
+}
 
-impl Default for PermissionRights {
-    fn default() -> Self {
-        Self(0)
+impl<'de> Deserialize<'de> for PermissionRights {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bits = u32::deserialize(deserializer)?;
+        Ok(Self::from_bits_retain(bits))
     }
 }
 
 impl PermissionRights {
-    pub fn empty() -> Self {
-        Self(0)
-    }
+    // Named single-flag constructors
+    pub fn read_any() -> Self { Self::READ_ANY }
+    pub fn create() -> Self { Self::CREATE }
+    pub fn edit_owned() -> Self { Self::EDIT_OWNED }
+    pub fn delete_owned() -> Self { Self::DELETE_OWNED }
+    pub fn edit_any() -> Self { Self::EDIT_ANY | Self::EDIT_OWNED }
+    pub fn delete_any() -> Self { Self::DELETE_ANY | Self::DELETE_OWNED }
+    pub fn folder_owner() -> Self { Self::FOLDER_OWNER | Self::FOLDER_VISIBLE }
+    pub fn folder_contact() -> Self { Self::FOLDER_CONTACT }
+    pub fn folder_visible() -> Self { Self::FOLDER_VISIBLE }
+    pub fn freebusy_simple() -> Self { Self::FREEBUSY_SIMPLE }
+    pub fn freebusy_detailed() -> Self { Self::FREEBUSY_DETAILED | Self::FREEBUSY_SIMPLE }
 
-    pub fn read_any() -> Self {
-        Self(RIGHT_READ_ANY)
-    }
+    // Named composite constructors (permission levels)
+    pub fn none() -> Self { Self::empty() }
+    pub fn reviewer() -> Self { Self::READ_ANY | Self::FOLDER_VISIBLE }
+    pub fn contributor() -> Self { Self::CREATE | Self::FOLDER_VISIBLE }
+    pub fn author() -> Self { Self::READ_ANY | Self::CREATE | Self::EDIT_OWNED | Self::DELETE_OWNED | Self::FOLDER_VISIBLE }
+    pub fn non_editing_author() -> Self { Self::READ_ANY | Self::CREATE | Self::DELETE_OWNED | Self::FOLDER_VISIBLE }
+    pub fn editor() -> Self { Self::READ_ANY | Self::CREATE | Self::edit_any() | Self::delete_any() | Self::FOLDER_VISIBLE }
+    pub fn publishing_author() -> Self { Self::READ_ANY | Self::CREATE | Self::EDIT_OWNED | Self::DELETE_OWNED | Self::CREATE_SUBFOLDER | Self::FOLDER_VISIBLE }
+    pub fn publishing_editor() -> Self { Self::READ_ANY | Self::CREATE | Self::edit_any() | Self::delete_any() | Self::CREATE_SUBFOLDER | Self::FOLDER_VISIBLE }
+    pub fn owner() -> Self { Self::READ_ANY | Self::CREATE | Self::edit_any() | Self::delete_any() | Self::CREATE_SUBFOLDER | Self::FOLDER_OWNER | Self::FOLDER_CONTACT | Self::FOLDER_VISIBLE }
+    pub fn freebusy() -> Self { Self::FREEBUSY_SIMPLE | Self::FREEBUSY_DETAILED | Self::FOLDER_VISIBLE }
 
-    pub fn create() -> Self {
-        Self(RIGHT_CREATE)
-    }
-
-    pub fn edit_owned() -> Self {
-        Self(RIGHT_EDIT_OWNED)
-    }
-
-    pub fn delete_owned() -> Self {
-        Self(RIGHT_DELETE_OWNED)
-    }
-
-    pub fn edit_any() -> Self {
-        Self(RIGHT_EDIT_ANY | RIGHT_EDIT_OWNED)
-    }
-
-    pub fn delete_any() -> Self {
-        Self(RIGHT_DELETE_ANY | RIGHT_DELETE_OWNED)
-    }
-
-    pub fn folder_owner() -> Self {
-        Self(RIGHT_FOLDER_OWNER | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn folder_contact() -> Self {
-        Self(RIGHT_FOLDER_CONTACT)
-    }
-
-    pub fn folder_visible() -> Self {
-        Self(RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn freebusy_simple() -> Self {
-        Self(RIGHT_FREEBUSY_SIMPLE)
-    }
-
-    pub fn freebusy_detailed() -> Self {
-        Self(RIGHT_FREEBUSY_DETAILED | RIGHT_FREEBUSY_SIMPLE)
-    }
-
-    pub fn none() -> Self {
-        Self(0)
-    }
-
-    pub fn reviewer() -> Self {
-        Self(RIGHT_READ_ANY | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn contributor() -> Self {
-        Self(RIGHT_CREATE | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn author() -> Self {
-        Self(RIGHT_READ_ANY | RIGHT_CREATE | RIGHT_EDIT_OWNED | RIGHT_DELETE_OWNED | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn non_editing_author() -> Self {
-        Self(RIGHT_READ_ANY | RIGHT_CREATE | RIGHT_DELETE_OWNED | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn editor() -> Self {
-        Self(RIGHT_READ_ANY | RIGHT_CREATE | RIGHT_EDIT_ANY | RIGHT_DELETE_ANY | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn publishing_author() -> Self {
-        Self(RIGHT_READ_ANY | RIGHT_CREATE | RIGHT_EDIT_OWNED | RIGHT_DELETE_OWNED | RIGHT_CREATE_SUBFOLDER | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn publishing_editor() -> Self {
-        Self(RIGHT_READ_ANY | RIGHT_CREATE | RIGHT_EDIT_ANY | RIGHT_DELETE_ANY | RIGHT_CREATE_SUBFOLDER | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn owner() -> Self {
-        Self(RIGHT_READ_ANY | RIGHT_CREATE | RIGHT_EDIT_ANY | RIGHT_DELETE_ANY | RIGHT_CREATE_SUBFOLDER | RIGHT_FOLDER_OWNER | RIGHT_FOLDER_CONTACT | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn freebusy() -> Self {
-        Self(RIGHT_FREEBUSY_SIMPLE | RIGHT_FREEBUSY_DETAILED | RIGHT_FOLDER_VISIBLE)
-    }
-
-    pub fn can_read_any(&self) -> bool {
-        self.0 & RIGHT_READ_ANY != 0
-    }
-
-    pub fn can_create(&self) -> bool {
-        self.0 & RIGHT_CREATE != 0
-    }
-
-    pub fn can_edit_owned(&self) -> bool {
-        self.0 & RIGHT_EDIT_OWNED != 0
-    }
-
-    pub fn can_delete_owned(&self) -> bool {
-        self.0 & RIGHT_DELETE_OWNED != 0
-    }
-
-    pub fn can_edit_any(&self) -> bool {
-        self.0 & RIGHT_EDIT_ANY != 0
-    }
-
-    pub fn can_delete_any(&self) -> bool {
-        self.0 & RIGHT_DELETE_ANY != 0
-    }
-
-    pub fn can_create_subfolder(&self) -> bool {
-        self.0 & RIGHT_CREATE_SUBFOLDER != 0
-    }
-
-    pub fn is_folder_owner(&self) -> bool {
-        self.0 & RIGHT_FOLDER_OWNER != 0
-    }
-
-    pub fn is_folder_contact(&self) -> bool {
-        self.0 & RIGHT_FOLDER_CONTACT != 0
-    }
-
-    pub fn is_folder_visible(&self) -> bool {
-        self.0 & RIGHT_FOLDER_VISIBLE != 0
-    }
-
-    pub fn can_freebusy_simple(&self) -> bool {
-        self.0 & RIGHT_FREEBUSY_SIMPLE != 0
-    }
-
-    pub fn can_freebusy_detailed(&self) -> bool {
-        self.0 & RIGHT_FREEBUSY_DETAILED != 0
-    }
-
-    pub fn bits(&self) -> u32 {
-        self.0
-    }
-
-    pub fn from_bits(bits: u32) -> Self {
-        Self(bits)
-    }
-
-    pub fn union(self, other: Self) -> Self {
-        Self(self.0 | other.0)
-    }
-
-    pub fn intersection(self, other: Self) -> Self {
-        Self(self.0 & other.0)
-    }
-
-    pub fn difference(self, other: Self) -> Self {
-        Self(self.0 & !other.0)
-    }
-
-    pub fn contains(&self, other: &Self) -> bool {
-        (self.0 & other.0) == other.0
-    }
+    // Convenience predicates (preserving the existing API names)
+    pub fn can_read_any(&self) -> bool { self.contains(Self::READ_ANY) }
+    pub fn can_create(&self) -> bool { self.contains(Self::CREATE) }
+    pub fn can_edit_owned(&self) -> bool { self.contains(Self::EDIT_OWNED) }
+    pub fn can_delete_owned(&self) -> bool { self.contains(Self::DELETE_OWNED) }
+    pub fn can_edit_any(&self) -> bool { self.contains(Self::EDIT_ANY) }
+    pub fn can_delete_any(&self) -> bool { self.contains(Self::DELETE_ANY) }
+    pub fn can_create_subfolder(&self) -> bool { self.contains(Self::CREATE_SUBFOLDER) }
+    pub fn is_folder_owner(&self) -> bool { self.contains(Self::FOLDER_OWNER) }
+    pub fn is_folder_contact(&self) -> bool { self.contains(Self::FOLDER_CONTACT) }
+    pub fn is_folder_visible(&self) -> bool { self.contains(Self::FOLDER_VISIBLE) }
+    pub fn can_freebusy_simple(&self) -> bool { self.contains(Self::FREEBUSY_SIMPLE) }
+    pub fn can_freebusy_detailed(&self) -> bool { self.contains(Self::FREEBUSY_DETAILED) }
 }
 
 impl fmt::Display for PermissionRights {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return write!(f, "None");
+        }
         let mut parts = Vec::new();
         if self.can_read_any() { parts.push("ReadAny"); }
         if self.can_create() { parts.push("Create"); }
@@ -201,23 +94,19 @@ impl fmt::Display for PermissionRights {
         if self.is_folder_visible() { parts.push("FolderVisible"); }
         if self.can_freebusy_simple() { parts.push("FreeBusySimple"); }
         if self.can_freebusy_detailed() { parts.push("FreeBusyDetailed"); }
-        if parts.is_empty() {
-            write!(f, "None")
-        } else {
-            write!(f, "{}", parts.join("|"))
-        }
+        write!(f, "{}", parts.join("|"))
     }
 }
 
 impl From<u32> for PermissionRights {
     fn from(value: u32) -> Self {
-        Self(value)
+        Self::from_bits_retain(value)
     }
 }
 
 impl From<PermissionRights> for u32 {
     fn from(value: PermissionRights) -> Self {
-        value.0
+        value.bits()
     }
 }
 
@@ -261,25 +150,25 @@ impl PermissionLevel {
         if rights.is_folder_owner() {
             return Self::Owner;
         }
-        if rights.contains(&PermissionRights::publishing_editor()) {
+        if rights.contains(PermissionRights::publishing_editor()) {
             return Self::PublishingEditor;
         }
-        if rights.contains(&PermissionRights::editor()) {
+        if rights.contains(PermissionRights::editor()) {
             return Self::Editor;
         }
-        if rights.contains(&PermissionRights::publishing_author()) {
+        if rights.contains(PermissionRights::publishing_author()) {
             return Self::PublishingAuthor;
         }
-        if rights.contains(&PermissionRights::author()) {
+        if rights.contains(PermissionRights::author()) {
             return Self::Author;
         }
-        if rights.contains(&PermissionRights::non_editing_author()) {
+        if rights.contains(PermissionRights::non_editing_author()) {
             return Self::NonEditingAuthor;
         }
-        if rights.contains(&PermissionRights::contributor()) {
+        if rights.contains(PermissionRights::contributor()) {
             return Self::Contributor;
         }
-        if rights.contains(&PermissionRights::reviewer()) {
+        if rights.contains(PermissionRights::reviewer()) {
             return Self::Reviewer;
         }
         if rights.can_freebusy_simple() {
@@ -418,7 +307,7 @@ impl CalendarPermission {
     }
 
     pub fn rights(&self) -> PermissionRights {
-        PermissionRights::from_bits(self.rights)
+        PermissionRights::from_bits_retain(self.rights)
     }
 
     pub fn set_rights(&mut self, rights: PermissionRights) {
@@ -601,8 +490,8 @@ mod tests {
     fn test_permission_rights_contains() {
         let editor = PermissionRights::editor();
         let author = PermissionRights::author();
-        assert!(editor.contains(&author));
-        assert!(!author.contains(&editor));
+        assert!(editor.contains(author));
+        assert!(!author.contains(editor));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,6 @@
 // src/storage.rs
 use anyhow::{Result, anyhow};
+use const_hex;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use reqwest_tracing::TracingMiddleware;
@@ -129,7 +130,7 @@ impl Storage {
         let payload = serde_json::to_vec(body)?;
         hasher.update(&payload);
         let digest = hasher.finalize();
-        Ok(digest.iter().map(|b| format!("{:02x}", b)).collect())
+        Ok(const_hex::encode(digest))
     }
 
     pub async fn post_json<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,7 +5,7 @@ use crate::calendar::{
     parse_ics_event, parse_datetime, render_ics,
 };
 use crate::models::AppState;
-use crate::util::{xml_escape, parse_datetime as util_parse_datetime};
+use crate::util::{normalize_email, xml_escape};
 use anyhow::{Result, anyhow};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -448,7 +448,7 @@ pub async fn apply_meeting_response(
     if let Some(attendee) = item
         .attendees
         .iter_mut()
-        .find(|a| a.email.eq_ignore_ascii_case(owner))
+        .find(|a| normalize_email(&a.email) == normalize_email(owner))
     {
         attendee.attendee_status = Some(status);
         attendee.partstat = Some(partstat.to_string());

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,69 +1,19 @@
 // src/util.rs
 
-use std::fmt::{self, Display};
+use std::borrow::Cow;
+use unicode_normalization::UnicodeNormalization;
 
-pub fn xml_escape(s: &str) -> String {
-    // Single-pass implementation for better performance
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '&' => result.push_str("&amp;"),
-            '<' => result.push_str("&lt;"),
-            '>' => result.push_str("&gt;"),
-            '"' => result.push_str("&quot;"),
-            '\'' => result.push_str("&apos;"),
-            c => result.push(c),
-        }
-    }
-    result
+/// Escape all XML special characters: `& < > " '`
+/// Delegates to `quick_xml::escape::escape` for standards compliance.
+pub fn xml_escape(s: &str) -> Cow<'_, str> {
+    quick_xml::escape::escape(s)
 }
 
-pub fn xml_escape_text(s: &str) -> String {
-    // Single-pass implementation for better performance
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '&' => result.push_str("&amp;"),
-            '<' => result.push_str("&lt;"),
-            '>' => result.push_str("&gt;"),
-            c => result.push(c),
-        }
-    }
-    result
-}
-
-pub struct EscapedXml<'a>(pub &'a str);
-
-impl Display for EscapedXml<'_> {
- fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-  for c in self.0.chars() {
-   match c {
-    '&' => write!(f, "&amp;"),
-    '<' => write!(f, "&lt;"),
-    '>' => write!(f, "&gt;"),
-    '"' => write!(f, "&quot;"),
-    '\'' => write!(f, "&apos;"),
-    c => write!(f, "{}", c),
-   }?;
-  }
-  Ok(())
- }
-}
-
-pub struct EscapedXmlText<'a>(pub &'a str);
-
-impl Display for EscapedXmlText<'_> {
- fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-  for c in self.0.chars() {
-   match c {
-    '&' => write!(f, "&amp;"),
-    '<' => write!(f, "&lt;"),
-    '>' => write!(f, "&gt;"),
-    c => write!(f, "{}", c),
-   }?;
-  }
-  Ok(())
- }
+/// Escape XML text content characters: `& < >`
+/// Delegates to `quick_xml::escape::partial_escape` per XML spec
+/// (only `&` and `<` are mandatory in PCDATA; `>` escaped for SGML compat).
+pub fn xml_escape_text(s: &str) -> Cow<'_, str> {
+    quick_xml::escape::partial_escape(s)
 }
 
 pub fn sanitize_path_segment(s: &str) -> String {
@@ -92,6 +42,23 @@ pub fn truncate_string(s: &str, max_len: usize) -> String {
         format!("{}...", &s[..end])
  }
 }
+/// Apply NFC Unicode normalization to a string.
+/// Ensures canonical byte representation for consistent comparison
+/// of internationalized text (e.g., email addresses with non-ASCII characters).
+pub fn nfc(input: &str) -> String {
+    input.nfc().collect()
+}
+
+/// Normalize an email address for consistent comparison and storage.
+/// Strips "mailto:" prefix, applies NFC Unicode normalization, and lowercases.
+/// This handles the common case where the same email arrives in different
+/// Unicode normalization forms (e.g., NFD from CalDAV vs NFC from EWS).
+pub fn normalize_email(email: &str) -> String {
+    let stripped = email.strip_prefix("mailto:").unwrap_or(
+        email.strip_prefix("MAILTO:").unwrap_or(email)
+    );
+    stripped.nfc().collect::<String>().to_ascii_lowercase()
+}
 
 #[cfg(test)]
 mod tests {
@@ -118,4 +85,28 @@ mod tests {
   assert_eq!(truncate_string("hello", 10), "hello");
   assert_eq!(truncate_string("hello world", 8), "hello...");
  }
+#[test]
+    fn test_nfc_normalization() {
+        // \u{00e9} = NFC (precomposed é)
+        // \u{0065}\u{0301} = NFD (e + combining acute accent)
+        let nfc_e: String = "\u{00e9}".nfc().collect();
+        let nfd_e: String = "\u{0065}\u{0301}".nfd().collect();
+        assert_eq!(nfc_e.len(), 2); // NFC: single precomposed char in UTF-8
+        assert_eq!(nfd_e.len(), 3); // NFD: base + combining accent
+        assert_eq!(super::nfc(&nfd_e), nfc_e);
+    }
+
+    #[test]
+    fn test_normalize_email() {
+        // Lowercases
+        assert_eq!(normalize_email("User@Example.COM"), "user@example.com");
+        // Strips mailto: prefix (case-insensitive)
+        assert_eq!(normalize_email("mailto:User@Example.COM"), "user@example.com");
+        assert_eq!(normalize_email("MAILTO:User@Example.COM"), "user@example.com");
+        // NFC-normalizes decomposed form (NFD \u{0065}\u{0301} = e + combining acute)
+        let nfd_email = "user@\u{0065}\u{0301}xample.com";
+        assert_eq!(normalize_email(nfd_email), "user@\u{00e9}xample.com");
+        // Already-normalized ASCII passes through unchanged
+        assert_eq!(normalize_email("alice@example.com"), "alice@example.com");
+    }
 }

--- a/src/wbxml.rs
+++ b/src/wbxml.rs
@@ -2,8 +2,6 @@
 use crate::util::xml_escape_text;
 use anyhow::{Result, anyhow};
 use base64::Engine;
-use std::collections::HashMap;
-use std::sync::LazyLock;
 
 const SWITCH_PAGE: u8 = 0x00;
 const END: u8 = 0x01;
@@ -13,9 +11,1011 @@ const LITERAL: u8 = 0x04;
 const STR_T: u8 = 0x83;
 const OPAQUE: u8 = 0xC3;
 
-static TAG_TO_NAME: LazyLock<HashMap<(u8, u8), &'static str>> = LazyLock::new(build_tag_to_name);
-static NAME_TO_TAG: LazyLock<HashMap<&'static str, (u8, u8)>> =
-    LazyLock::new(|| TAG_TO_NAME.iter().map(|(&k, &v)| (v, k)).collect());
+static TAG_TO_NAME: phf::Map<[u8; 2], &'static str> = phf::phf_map! {
+    [0u8, 0x05u8] => "Sync",
+    [0u8, 0x06u8] => "Responses",
+    [0u8, 0x07u8] => "Add",
+    [0u8, 0x08u8] => "Change",
+    [0u8, 0x09u8] => "Delete",
+    [0u8, 0x0Au8] => "Fetch",
+    [0u8, 0x0Bu8] => "SyncKey",
+    [0u8, 0x0Cu8] => "ClientId",
+    [0u8, 0x0Du8] => "ServerId",
+    [0u8, 0x0Eu8] => "Status",
+    [0u8, 0x0Fu8] => "Collection",
+    [0u8, 0x10u8] => "Class",
+    [0u8, 0x12u8] => "CollectionId",
+    [0u8, 0x13u8] => "GetChanges",
+    [0u8, 0x14u8] => "MoreAvailable",
+    [0u8, 0x15u8] => "WindowSize",
+    [0u8, 0x16u8] => "Commands",
+    [0u8, 0x17u8] => "Options",
+    [0u8, 0x18u8] => "FilterType",
+    [0u8, 0x1Bu8] => "Conflict",
+    [0u8, 0x1Cu8] => "Collections",
+    [0u8, 0x1Du8] => "ApplicationData",
+    [0u8, 0x1Eu8] => "DeletesAsMoves",
+    [0u8, 0x20u8] => "Supported",
+    [0u8, 0x21u8] => "SoftDelete",
+    [0u8, 0x22u8] => "MIMESupport",
+    [0u8, 0x23u8] => "MIMETruncation",
+    [0u8, 0x24u8] => "Wait",
+    [0u8, 0x25u8] => "Limit",
+    [0u8, 0x26u8] => "Partial",
+    [0u8, 0x27u8] => "ConversationMode",
+    [0u8, 0x28u8] => "MaxItems",
+    [0u8, 0x29u8] => "HeartbeatInterval",
+    [1u8, 0x05u8] => "Contacts:Anniversary",
+    [1u8, 0x06u8] => "Contacts:AssistantName",
+    [1u8, 0x07u8] => "Contacts:AssistantPhoneNumber",
+    [1u8, 0x08u8] => "Contacts:Birthday",
+    [1u8, 0x13u8] => "Contacts:BusinessPhoneNumber",
+    [1u8, 0x19u8] => "Contacts:CompanyName",
+    [1u8, 0x1Bu8] => "Contacts:Email1Address",
+    [1u8, 0x1Cu8] => "Contacts:Email2Address",
+    [1u8, 0x1Du8] => "Contacts:Email3Address",
+    [1u8, 0x1Fu8] => "Contacts:FirstName",
+    [1u8, 0x21u8] => "Contacts:HomeCity",
+    [1u8, 0x22u8] => "Contacts:HomeCountry",
+    [1u8, 0x26u8] => "Contacts:HomePhoneNumber",
+    [1u8, 0x29u8] => "Contacts:LastName",
+    [1u8, 0x2Bu8] => "Contacts:MobilePhoneNumber",
+    [1u8, 0x2Fu8] => "Contacts:Suffix",
+    [1u8, 0x30u8] => "Contacts:Title",
+    [1u8, 0x33u8] => "Contacts:JobTitle",
+    [1u8, 0x35u8] => "Contacts:MiddleName",
+    [1u8, 0x37u8] => "Contacts:NickName",
+    [1u8, 0x39u8] => "Contacts:OfficeLocation",
+    [1u8, 0x45u8] => "Contacts:WebPage",
+    [1u8, 0x47u8] => "Contacts:YomiCompanyName",
+    [1u8, 0x48u8] => "Contacts:YomiFirstName",
+    [1u8, 0x49u8] => "Contacts:YomiLastName",
+    [2u8, 0x05u8] => "Email:Attachment",
+    [2u8, 0x06u8] => "Email:Attachments",
+    [2u8, 0x07u8] => "Email:AttName",
+    [2u8, 0x08u8] => "Email:AttSize",
+    [2u8, 0x0Cu8] => "Email:Body",
+    [2u8, 0x0Eu8] => "Email:DateReceived",
+    [2u8, 0x11u8] => "Email:DisplayTo",
+    [2u8, 0x14u8] => "Email:Subject",
+    [2u8, 0x15u8] => "Email:Read",
+    [2u8, 0x16u8] => "Email:To",
+    [2u8, 0x17u8] => "Email:Cc",
+    [2u8, 0x18u8] => "Email:From",
+    [2u8, 0x19u8] => "Email:Reply-To",
+    [2u8, 0x1Au8] => "Email:AllDayEvent",
+    [2u8, 0x1Bu8] => "Email:Categories",
+    [2u8, 0x1Cu8] => "Email:Category",
+    [2u8, 0x1Du8] => "Email:DtStamp",
+    [2u8, 0x1Eu8] => "Email:EndTime",
+    [2u8, 0x1Fu8] => "Email:InstanceType",
+    [2u8, 0x20u8] => "Email:BusyStatus",
+    [2u8, 0x24u8] => "Email:Location",
+    [2u8, 0x25u8] => "Email:MeetingRequest",
+    [2u8, 0x26u8] => "Email:Organizer",
+    [2u8, 0x28u8] => "Email:Recurrence",
+    [2u8, 0x2Bu8] => "Email:Reminder",
+    [2u8, 0x2Cu8] => "Email:RequiredAttendees",
+    [2u8, 0x2Du8] => "Email:OptionalAttendees",
+    [2u8, 0x2Eu8] => "Email:ResourceAttendees",
+    [2u8, 0x2Fu8] => "Email:ResponseRequested",
+    [2u8, 0x30u8] => "Email:Sensitivity",
+    [2u8, 0x31u8] => "Email:StartTime",
+    [2u8, 0x32u8] => "Email:Timezone",
+    [2u8, 0x33u8] => "Email:GlobalObjId",
+    [2u8, 0x34u8] => "Email:ThreadTopic",
+    [2u8, 0x39u8] => "Email:InternetCPID",
+    [2u8, 0x3Au8] => "Email:Flag",
+    [2u8, 0x3Bu8] => "Email:FlagStatus",
+    [2u8, 0x3Cu8] => "Email:ContentClass",
+    [2u8, 0x3Du8] => "Email:FlagType",
+    [2u8, 0x3Eu8] => "Email:CompleteTime",
+    [2u8, 0x40u8] => "Email:DisallowNewTimeProposal",
+    [4u8, 0x05u8] => "Calendar:Timezone",
+    [4u8, 0x06u8] => "Calendar:AllDayEvent",
+    [4u8, 0x07u8] => "Calendar:Attendees",
+    [4u8, 0x08u8] => "Calendar:Attendee",
+    [4u8, 0x09u8] => "Calendar:Email",
+    [4u8, 0x0Au8] => "Calendar:Name",
+    [4u8, 0x0Bu8] => "Calendar:Body",
+    [4u8, 0x0Du8] => "Calendar:BusyStatus",
+    [4u8, 0x0Eu8] => "Calendar:Categories",
+    [4u8, 0x0Fu8] => "Calendar:Category",
+    [4u8, 0x11u8] => "Calendar:DtStamp",
+    [4u8, 0x12u8] => "Calendar:EndTime",
+    [4u8, 0x13u8] => "Calendar:Exception",
+    [4u8, 0x14u8] => "Calendar:Exceptions",
+    [4u8, 0x15u8] => "Calendar:Deleted",
+    [4u8, 0x16u8] => "Calendar:ExceptionStartTime",
+    [4u8, 0x17u8] => "Calendar:Location",
+    [4u8, 0x18u8] => "Calendar:MeetingStatus",
+    [4u8, 0x19u8] => "Calendar:OrganizerEmail",
+    [4u8, 0x1Au8] => "Calendar:OrganizerName",
+    [4u8, 0x1Bu8] => "Calendar:Recurrence",
+    [4u8, 0x1Cu8] => "Calendar:Type",
+    [4u8, 0x1Du8] => "Calendar:Until",
+    [4u8, 0x1Eu8] => "Calendar:Occurrences",
+    [4u8, 0x1Fu8] => "Calendar:Interval",
+    [4u8, 0x20u8] => "Calendar:DayOfWeek",
+    [4u8, 0x21u8] => "Calendar:DayOfMonth",
+    [4u8, 0x22u8] => "Calendar:WeekOfMonth",
+    [4u8, 0x23u8] => "Calendar:MonthOfYear",
+    [4u8, 0x24u8] => "Calendar:Reminder",
+    [4u8, 0x25u8] => "Calendar:Sensitivity",
+    [4u8, 0x26u8] => "Calendar:Subject",
+    [4u8, 0x27u8] => "Calendar:StartTime",
+    [4u8, 0x28u8] => "Calendar:UID",
+    [4u8, 0x29u8] => "Calendar:AttendeeStatus",
+    [4u8, 0x2Au8] => "Calendar:AttendeeType",
+    [4u8, 0x33u8] => "Calendar:DisallowNewTimeProposal",
+    [4u8, 0x34u8] => "Calendar:ResponseRequested",
+    [4u8, 0x35u8] => "Calendar:AppointmentReplyTime",
+    [4u8, 0x36u8] => "Calendar:ResponseType",
+    [4u8, 0x37u8] => "Calendar:CalendarType",
+    [4u8, 0x38u8] => "Calendar:IsLeapMonth",
+    [4u8, 0x39u8] => "Calendar:FirstDayOfWeek",
+    [4u8, 0x3Au8] => "Calendar:OnlineMeetingConfLink",
+    [4u8, 0x3Bu8] => "Calendar:OnlineMeetingExternalLink",
+    [4u8, 0x3Cu8] => "Calendar:ClientUid",
+    [4u8, 0x3Du8] => "Calendar:StartTimeZoneId",
+    [4u8, 0x3Eu8] => "Calendar:StartTimeZone",
+    [4u8, 0x3Fu8] => "Calendar:EndTimeZone",
+    [4u8, 0x40u8] => "Calendar:EndTimeZoneId",
+    [5u8, 0x05u8] => "MoveItems",
+    [5u8, 0x06u8] => "Move",
+    [5u8, 0x07u8] => "SrcMsgId",
+    [5u8, 0x08u8] => "SrcFldId",
+    [5u8, 0x09u8] => "DstFldId",
+    [5u8, 0x0Au8] => "MoveResponse",
+    [5u8, 0x0Bu8] => "MoveStatus",
+    [6u8, 0x05u8] => "GetItemEstimate",
+    [6u8, 0x06u8] => "GIEVersion",
+    [6u8, 0x07u8] => "GIECollections",
+    [6u8, 0x08u8] => "GIECollection",
+    [6u8, 0x09u8] => "GIEClass",
+    [6u8, 0x0Au8] => "GIECollectionId",
+    [6u8, 0x0Bu8] => "DateTime",
+    [6u8, 0x0Cu8] => "Estimate",
+    [6u8, 0x0Du8] => "Response",
+    [6u8, 0x0Eu8] => "Status",
+    [7u8, 0x07u8] => "DisplayName",
+    [7u8, 0x08u8] => "ServerId",
+    [7u8, 0x09u8] => "ParentId",
+    [7u8, 0x0Au8] => "Type",
+    [7u8, 0x0Cu8] => "Status",
+    [7u8, 0x0Eu8] => "Changes",
+    [7u8, 0x0Fu8] => "Add",
+    [7u8, 0x10u8] => "Delete",
+    [7u8, 0x11u8] => "Update",
+    [7u8, 0x12u8] => "SyncKey",
+    [7u8, 0x13u8] => "FolderCreate",
+    [7u8, 0x14u8] => "FolderDelete",
+    [7u8, 0x15u8] => "FolderUpdate",
+    [7u8, 0x16u8] => "FolderSync",
+    [7u8, 0x17u8] => "Count",
+    [8u8, 0x05u8] => "CalendarId",
+    [8u8, 0x06u8] => "MeetingCollectionId",
+    [8u8, 0x07u8] => "MeetingResponse",
+    [8u8, 0x08u8] => "RequestId",
+    [8u8, 0x09u8] => "Request",
+    [8u8, 0x0Au8] => "Result",
+    [8u8, 0x0Bu8] => "Status",
+    [8u8, 0x0Cu8] => "UserResponse",
+    [8u8, 0x0Eu8] => "InstanceId",
+    [8u8, 0x0Fu8] => "LongId",
+    [8u8, 0x10u8] => "ProposedStartTime",
+    [8u8, 0x11u8] => "ProposedEndTime",
+    [8u8, 0x12u8] => "SendResponse",
+    [9u8, 0x08u8] => "Tasks:Complete",
+    [9u8, 0x09u8] => "Tasks:DateCompleted",
+    [9u8, 0x0Du8] => "Tasks:DueDate",
+    [9u8, 0x0Fu8] => "Tasks:Importance",
+    [9u8, 0x17u8] => "Tasks:StartDate",
+    [9u8, 0x18u8] => "Tasks:Subject",
+    [9u8, 0x19u8] => "Tasks:ReminderSet",
+    [9u8, 0x1Au8] => "Tasks:ReminderTime",
+    [9u8, 0x1Bu8] => "Tasks:Sensitivity",
+    [9u8, 0x1Cu8] => "Tasks:Recurrence",
+    [9u8, 0x1Du8] => "Tasks:Type",
+    [9u8, 0x1Eu8] => "Tasks:Start",
+    [9u8, 0x1Fu8] => "Tasks:Until",
+    [9u8, 0x20u8] => "Tasks:Occurrences",
+    [9u8, 0x21u8] => "Tasks:Interval",
+    [9u8, 0x22u8] => "Tasks:DayOfWeek",
+    [9u8, 0x23u8] => "Tasks:DayOfMonth",
+    [9u8, 0x24u8] => "Tasks:WeekOfMonth",
+    [9u8, 0x25u8] => "Tasks:MonthOfYear",
+    [9u8, 0x26u8] => "Tasks:Regenerate",
+    [9u8, 0x27u8] => "Tasks:DeadOccur",
+    [9u8, 0x28u8] => "Tasks:Categories",
+    [9u8, 0x29u8] => "Tasks:Category",
+    [10u8, 0x05u8] => "ResolveRecipients",
+    [10u8, 0x06u8] => "Response",
+    [10u8, 0x07u8] => "Status",
+    [10u8, 0x08u8] => "Type",
+    [10u8, 0x09u8] => "Recipient",
+    [10u8, 0x0Au8] => "DisplayName",
+    [10u8, 0x0Bu8] => "EmailAddress",
+    [10u8, 0x0Cu8] => "Certificates",
+    [10u8, 0x0Du8] => "Certificate",
+    [10u8, 0x0Eu8] => "MiniCertificate",
+    [10u8, 0x0Fu8] => "Options",
+    [10u8, 0x10u8] => "To",
+    [10u8, 0x11u8] => "CertificateRetrieval",
+    [10u8, 0x12u8] => "RecipientCount",
+    [10u8, 0x13u8] => "MaxCertificates",
+    [10u8, 0x14u8] => "MaxAmbiguousRecipients",
+    [10u8, 0x15u8] => "CertificateCount",
+    [10u8, 0x16u8] => "Availability",
+    [10u8, 0x17u8] => "StartTime",
+    [10u8, 0x18u8] => "EndTime",
+    [10u8, 0x19u8] => "MergedFreeBusy",
+    [10u8, 0x1Au8] => "Picture",
+    [10u8, 0x1Bu8] => "MaxSize",
+    [10u8, 0x1Cu8] => "Data",
+    [10u8, 0x1Du8] => "MaxPictures",
+    [11u8, 0x05u8] => "ValidateCert",
+    [11u8, 0x06u8] => "Certificates",
+    [11u8, 0x07u8] => "Certificate",
+    [11u8, 0x08u8] => "CertificateChain",
+    [11u8, 0x09u8] => "CheckCRL",
+    [11u8, 0x0Au8] => "CertificateStatus",
+    [11u8, 0x0Bu8] => "Status",
+    [12u8, 0x05u8] => "Contacts2:CustomerId",
+    [12u8, 0x06u8] => "Contacts2:GovernmentId",
+    [12u8, 0x07u8] => "Contacts2:IMAddress",
+    [12u8, 0x08u8] => "Contacts2:IMAddress2",
+    [12u8, 0x09u8] => "Contacts2:IMAddress3",
+    [12u8, 0x0Au8] => "Contacts2:ManagerName",
+    [12u8, 0x0Bu8] => "Contacts2:CompanyMainPhone",
+    [12u8, 0x0Cu8] => "Contacts2:AccountName",
+    [12u8, 0x0Du8] => "Contacts2:MMS",
+    [12u8, 0x0Eu8] => "Contacts2:NickName",
+    [13u8, 0x05u8] => "Ping",
+    [13u8, 0x07u8] => "Status",
+    [13u8, 0x08u8] => "HeartbeatInterval",
+    [13u8, 0x09u8] => "Folders",
+    [13u8, 0x0Au8] => "Folder",
+    [13u8, 0x0Bu8] => "Id",
+    [13u8, 0x0Cu8] => "Class",
+    [13u8, 0x0Du8] => "MaxFolders",
+    [14u8, 0x05u8] => "Provision",
+    [14u8, 0x06u8] => "Policies",
+    [14u8, 0x07u8] => "Policy",
+    [14u8, 0x08u8] => "PolicyType",
+    [14u8, 0x09u8] => "PolicyKey",
+    [14u8, 0x0Au8] => "Data",
+    [14u8, 0x0Bu8] => "Status",
+    [14u8, 0x0Cu8] => "RemoteWipe",
+    [14u8, 0x0Du8] => "EASProvisionDoc",
+    [14u8, 0x0Eu8] => "DevicePasswordEnabled",
+    [14u8, 0x0Fu8] => "AlphanumericDevicePasswordRequired",
+    [14u8, 0x10u8] => "RequireStorageCardEncryption",
+    [14u8, 0x11u8] => "PasswordRecoveryEnabled",
+    [14u8, 0x13u8] => "AttachmentsEnabled",
+    [14u8, 0x14u8] => "MinDevicePasswordLength",
+    [14u8, 0x15u8] => "MaxInactivityTimeDeviceLock",
+    [14u8, 0x16u8] => "MaxDevicePasswordFailedAttempts",
+    [14u8, 0x17u8] => "MaxAttachmentSize",
+    [14u8, 0x18u8] => "AllowSimpleDevicePassword",
+    [14u8, 0x19u8] => "DevicePasswordExpiration",
+    [14u8, 0x1Au8] => "DevicePasswordHistory",
+    [14u8, 0x1Bu8] => "AllowStorageCard",
+    [14u8, 0x1Cu8] => "AllowCamera",
+    [14u8, 0x1Du8] => "RequireDeviceEncryption",
+    [14u8, 0x1Eu8] => "AllowUnsignedApplications",
+    [14u8, 0x1Fu8] => "AllowUnsignedInstallationPackages",
+    [14u8, 0x20u8] => "MinDevicePasswordComplexCharacters",
+    [14u8, 0x21u8] => "AllowWifi",
+    [14u8, 0x22u8] => "AllowTextMessaging",
+    [14u8, 0x23u8] => "AllowPOPIMAPEmail",
+    [14u8, 0x24u8] => "AllowBluetooth",
+    [14u8, 0x25u8] => "AllowIrDA",
+    [14u8, 0x26u8] => "RequireManualSyncWhenRoaming",
+    [14u8, 0x27u8] => "AllowDesktopSync",
+    [14u8, 0x28u8] => "MaxCalendarAgeFilter",
+    [14u8, 0x29u8] => "AllowHTMLEmail",
+    [14u8, 0x2Au8] => "MaxEmailAgeFilter",
+    [14u8, 0x2Bu8] => "MaxEmailBodyTruncationSize",
+    [14u8, 0x2Cu8] => "MaxEmailHTMLBodyTruncationSize",
+    [14u8, 0x2Du8] => "RequireSignedSMIMEMessages",
+    [14u8, 0x2Eu8] => "RequireEncryptedSMIMEMessages",
+    [14u8, 0x2Fu8] => "RequireSignedSMIMEAlgorithm",
+    [14u8, 0x30u8] => "RequireEncryptionSMIMEAlgorithm",
+    [14u8, 0x31u8] => "AllowSMIMEEncryptionAlgorithmNegotiation",
+    [14u8, 0x32u8] => "AllowSMIMESoftCerts",
+    [14u8, 0x33u8] => "AllowBrowser",
+    [14u8, 0x34u8] => "AllowConsumerEmail",
+    [14u8, 0x35u8] => "AllowRemoteDesktop",
+    [14u8, 0x36u8] => "AllowInternetSharing",
+    [14u8, 0x37u8] => "UnapprovedInROMApplicationList",
+    [14u8, 0x38u8] => "ApplicationName",
+    [14u8, 0x39u8] => "ApprovedApplicationList",
+    [14u8, 0x3Au8] => "Hash",
+    [15u8, 0x05u8] => "Search",
+    [15u8, 0x07u8] => "Store",
+    [15u8, 0x08u8] => "Name",
+    [15u8, 0x09u8] => "Query",
+    [15u8, 0x0Au8] => "Options",
+    [15u8, 0x0Bu8] => "Range",
+    [15u8, 0x0Cu8] => "Status",
+    [15u8, 0x0Du8] => "Response",
+    [15u8, 0x0Eu8] => "Result",
+    [15u8, 0x0Fu8] => "Properties",
+    [15u8, 0x10u8] => "Total",
+    [15u8, 0x11u8] => "EqualTo",
+    [15u8, 0x12u8] => "Value",
+    [15u8, 0x13u8] => "And",
+    [15u8, 0x14u8] => "Or",
+    [15u8, 0x15u8] => "FreeText",
+    [15u8, 0x17u8] => "DeepTraversal",
+    [15u8, 0x18u8] => "LongId",
+    [15u8, 0x19u8] => "RebuildResults",
+    [15u8, 0x1Au8] => "LeafName",
+    [15u8, 0x1Bu8] => "Class",
+    [15u8, 0x1Cu8] => "CollectionId",
+    [15u8, 0x1Du8] => "QueryId",
+    [15u8, 0x1Eu8] => "MaxResults",
+    [16u8, 0x05u8] => "GAL:DisplayName",
+    [16u8, 0x06u8] => "GAL:Phone",
+    [16u8, 0x07u8] => "GAL:Office",
+    [16u8, 0x08u8] => "GAL:Title",
+    [16u8, 0x09u8] => "GAL:Company",
+    [16u8, 0x0Au8] => "GAL:Alias",
+    [16u8, 0x0Bu8] => "GAL:FirstName",
+    [16u8, 0x0Cu8] => "GAL:LastName",
+    [16u8, 0x0Du8] => "GAL:HomePhone",
+    [16u8, 0x0Eu8] => "GAL:MobilePhone",
+    [16u8, 0x0Fu8] => "GAL:EmailAddress",
+    [16u8, 0x10u8] => "GAL:Picture",
+    [16u8, 0x11u8] => "GAL:Status",
+    [16u8, 0x12u8] => "GAL:Data",
+    [17u8, 0x05u8] => "AirSyncBase:BodyPreference",
+    [17u8, 0x06u8] => "AirSyncBase:Type",
+    [17u8, 0x07u8] => "AirSyncBase:TruncationSize",
+    [17u8, 0x08u8] => "AirSyncBase:AllOrNone",
+    [17u8, 0x0Au8] => "AirSyncBase:Body",
+    [17u8, 0x0Bu8] => "AirSyncBase:Data",
+    [17u8, 0x0Cu8] => "AirSyncBase:EstimatedDataSize",
+    [17u8, 0x0Du8] => "AirSyncBase:Truncated",
+    [17u8, 0x0Eu8] => "AirSyncBase:Attachments",
+    [17u8, 0x0Fu8] => "AirSyncBase:Attachment",
+    [17u8, 0x10u8] => "AirSyncBase:DisplayName",
+    [17u8, 0x11u8] => "AirSyncBase:FileReference",
+    [17u8, 0x12u8] => "AirSyncBase:Method",
+    [17u8, 0x13u8] => "AirSyncBase:ContentId",
+    [17u8, 0x14u8] => "AirSyncBase:ContentLocation",
+    [17u8, 0x15u8] => "AirSyncBase:IsInline",
+    [17u8, 0x16u8] => "AirSyncBase:NativeBodyType",
+    [17u8, 0x17u8] => "AirSyncBase:ContentType",
+    [17u8, 0x18u8] => "AirSyncBase:Preview",
+    [17u8, 0x19u8] => "AirSyncBase:BodyPartPreference",
+    [17u8, 0x1Au8] => "AirSyncBase:BodyPart",
+    [17u8, 0x1Bu8] => "AirSyncBase:Status",
+    [17u8, 0x1Cu8] => "AirSyncBase:Add",
+    [17u8, 0x1Du8] => "AirSyncBase:Delete",
+    [17u8, 0x1Eu8] => "AirSyncBase:ClientId",
+    [17u8, 0x1Fu8] => "AirSyncBase:Content",
+    [17u8, 0x20u8] => "AirSyncBase:Location",
+    [17u8, 0x21u8] => "AirSyncBase:Annotation",
+    [17u8, 0x22u8] => "AirSyncBase:Street",
+    [17u8, 0x23u8] => "AirSyncBase:City",
+    [17u8, 0x24u8] => "AirSyncBase:State",
+    [17u8, 0x25u8] => "AirSyncBase:Country",
+    [17u8, 0x26u8] => "AirSyncBase:PostalCode",
+    [17u8, 0x27u8] => "AirSyncBase:Latitude",
+    [17u8, 0x28u8] => "AirSyncBase:Longitude",
+    [17u8, 0x29u8] => "AirSyncBase:Accuracy",
+    [17u8, 0x2Au8] => "AirSyncBase:Altitude",
+    [17u8, 0x2Bu8] => "AirSyncBase:AltitudeAccuracy",
+    [17u8, 0x2Cu8] => "AirSyncBase:LocationUri",
+    [17u8, 0x2Du8] => "AirSyncBase:InstanceId",
+    [18u8, 0x05u8] => "Settings",
+    [18u8, 0x06u8] => "Status",
+    [18u8, 0x07u8] => "Get",
+    [18u8, 0x08u8] => "Set",
+    [18u8, 0x09u8] => "Oof",
+    [18u8, 0x0Au8] => "OofState",
+    [18u8, 0x0Bu8] => "StartTime",
+    [18u8, 0x0Cu8] => "EndTime",
+    [18u8, 0x0Du8] => "OofMessage",
+    [18u8, 0x0Eu8] => "AppliesToInternal",
+    [18u8, 0x0Fu8] => "AppliesToExternalKnown",
+    [18u8, 0x10u8] => "AppliesToExternalUnknown",
+    [18u8, 0x11u8] => "Enabled",
+    [18u8, 0x12u8] => "ReplyMessage",
+    [18u8, 0x13u8] => "BodyType",
+    [18u8, 0x14u8] => "DevicePassword",
+    [18u8, 0x15u8] => "Password",
+    [18u8, 0x16u8] => "DeviceInformation",
+    [18u8, 0x17u8] => "Model",
+    [18u8, 0x18u8] => "IMEI",
+    [18u8, 0x19u8] => "FriendlyName",
+    [18u8, 0x1Au8] => "OS",
+    [18u8, 0x1Bu8] => "OSLanguage",
+    [18u8, 0x1Cu8] => "PhoneNumber",
+    [18u8, 0x1Du8] => "UserInformation",
+    [18u8, 0x1Eu8] => "EmailAddresses",
+    [18u8, 0x1Fu8] => "SMTPAddress",
+    [18u8, 0x20u8] => "UserAgent",
+    [18u8, 0x21u8] => "EnableOutboundSMS",
+    [18u8, 0x22u8] => "MobileOperator",
+    [18u8, 0x23u8] => "PrimarySmtpAddress",
+    [18u8, 0x24u8] => "Accounts",
+    [18u8, 0x25u8] => "Account",
+    [18u8, 0x26u8] => "AccountId",
+    [18u8, 0x27u8] => "AccountName",
+    [18u8, 0x28u8] => "UserDisplayName",
+    [18u8, 0x29u8] => "SendDisabled",
+    [18u8, 0x2Bu8] => "RightsManagementInformation",
+    [19u8, 0x05u8] => "DocumentLibrary:LinkId",
+    [19u8, 0x06u8] => "DocumentLibrary:DisplayName",
+    [19u8, 0x07u8] => "DocumentLibrary:IsFolder",
+    [19u8, 0x08u8] => "DocumentLibrary:CreationDate",
+    [19u8, 0x09u8] => "DocumentLibrary:LastModifiedDate",
+    [19u8, 0x0Au8] => "DocumentLibrary:IsHidden",
+    [19u8, 0x0Bu8] => "DocumentLibrary:ContentLength",
+    [19u8, 0x0Cu8] => "DocumentLibrary:ContentType",
+    [20u8, 0x05u8] => "ItemOperations",
+    [20u8, 0x06u8] => "Fetch",
+    [20u8, 0x07u8] => "Store",
+    [20u8, 0x08u8] => "Options",
+    [20u8, 0x09u8] => "Range",
+    [20u8, 0x0Au8] => "Total",
+    [20u8, 0x0Bu8] => "Properties",
+    [20u8, 0x0Cu8] => "Data",
+    [20u8, 0x0Du8] => "Status",
+    [20u8, 0x0Eu8] => "Response",
+    [20u8, 0x0Fu8] => "Version",
+    [20u8, 0x10u8] => "Schema",
+    [20u8, 0x11u8] => "Part",
+    [20u8, 0x12u8] => "EmptyFolderContents",
+    [20u8, 0x13u8] => "DeleteSubFolders",
+    [20u8, 0x14u8] => "UserName",
+    [20u8, 0x15u8] => "IOPassword",
+    [20u8, 0x16u8] => "Move",
+    [20u8, 0x17u8] => "DstFldId",
+    [20u8, 0x18u8] => "ConversationId",
+    [20u8, 0x19u8] => "MoveAlways",
+    [21u8, 0x05u8] => "SendMail",
+    [21u8, 0x06u8] => "SmartForward",
+    [21u8, 0x07u8] => "SmartReply",
+    [21u8, 0x08u8] => "SaveInSentItems",
+    [21u8, 0x09u8] => "ReplaceMime",
+    [21u8, 0x0Bu8] => "Mime",
+    [21u8, 0x0Cu8] => "ClientId",
+    [21u8, 0x0Du8] => "Status",
+    [21u8, 0x0Eu8] => "AccountId",
+    [21u8, 0x0Fu8] => "Forwardees",
+    [21u8, 0x10u8] => "Forwardee",
+    [21u8, 0x11u8] => "ForwardeeName",
+    [21u8, 0x12u8] => "ForwardeeEmail",
+    [22u8, 0x05u8] => "Email2:UmCallerId",
+    [22u8, 0x06u8] => "Email2:UmUserNotes",
+    [22u8, 0x07u8] => "Email2:UmAttDuration",
+    [22u8, 0x08u8] => "Email2:UmAttOrder",
+    [22u8, 0x09u8] => "Email2:ConversationId",
+    [22u8, 0x0Au8] => "Email2:ConversationIndex",
+    [22u8, 0x0Bu8] => "Email2:LastVerbExecuted",
+    [22u8, 0x0Cu8] => "Email2:LastVerbExecutionTime",
+    [22u8, 0x0Du8] => "Email2:ReceivedAsBcc",
+    [22u8, 0x0Eu8] => "Email2:Sender",
+    [22u8, 0x0Fu8] => "Email2:CalendarType",
+    [22u8, 0x10u8] => "Email2:IsLeapMonth",
+    [22u8, 0x11u8] => "Email2:AccountId",
+    [22u8, 0x12u8] => "Email2:FirstDayOfWeek",
+    [22u8, 0x13u8] => "Email2:MeetingMessageType",
+    [23u8, 0x05u8] => "Notes:Subject",
+    [23u8, 0x06u8] => "Notes:MessageClass",
+    [23u8, 0x07u8] => "Notes:LastModifiedDate",
+    [23u8, 0x08u8] => "Notes:Categories",
+    [23u8, 0x09u8] => "Notes:Category",
+    [23u8, 0x0Bu8] => "Notes:Body",
+    [24u8, 0x05u8] => "RightsManagement:RightsManagementSupport",
+    [24u8, 0x06u8] => "RightsManagement:RightsManagementTemplates",
+    [24u8, 0x07u8] => "RightsManagement:RightsManagementTemplate",
+    [24u8, 0x08u8] => "RightsManagement:RightsManagementLicense",
+    [24u8, 0x09u8] => "RightsManagement:EditAllowed",
+    [24u8, 0x0Au8] => "RightsManagement:ReplyAllowed",
+    [24u8, 0x0Bu8] => "RightsManagement:ReplyAllAllowed",
+    [24u8, 0x0Cu8] => "RightsManagement:ForwardAllowed",
+    [24u8, 0x0Du8] => "RightsManagement:ModifyRecipientsAllowed",
+    [24u8, 0x0Eu8] => "RightsManagement:ExtractAllowed",
+    [24u8, 0x0Fu8] => "RightsManagement:PrintAllowed",
+    [24u8, 0x10u8] => "RightsManagement:ExportAllowed",
+    [24u8, 0x11u8] => "RightsManagement:ProgrammaticAccessAllowed",
+    [24u8, 0x12u8] => "RightsManagement:RMOwner",
+    [24u8, 0x13u8] => "RightsManagement:ContentExpiryDate",
+    [24u8, 0x14u8] => "RightsManagement:ContentExpiryDateString",
+    [24u8, 0x15u8] => "RightsManagement:ContentExpiryInterval",
+    [24u8, 0x16u8] => "RightsManagement:ContentExpiryIntervalType",
+    [24u8, 0x17u8] => "RightsManagement:TemplateID",
+    [24u8, 0x18u8] => "RightsManagement:TemplateName",
+    [24u8, 0x19u8] => "RightsManagement:TemplateDescription",
+    [24u8, 0x1Au8] => "RightsManagement:ContentOwner",
+    [24u8, 0x1Bu8] => "RightsManagement:RemoveRightsManagementDistribution",
+};
+
+static NAME_TO_TAG: phf::Map<&'static str, [u8; 2]> = phf::phf_map! {
+    "Sync" => [0u8, 0x05u8],
+    "Responses" => [0u8, 0x06u8],
+    "Change" => [0u8, 0x08u8],
+    "Collection" => [0u8, 0x0Fu8],
+    "GetChanges" => [0u8, 0x13u8],
+    "MoreAvailable" => [0u8, 0x14u8],
+    "WindowSize" => [0u8, 0x15u8],
+    "Commands" => [0u8, 0x16u8],
+    "FilterType" => [0u8, 0x18u8],
+    "Conflict" => [0u8, 0x1Bu8],
+    "Collections" => [0u8, 0x1Cu8],
+    "ApplicationData" => [0u8, 0x1Du8],
+    "DeletesAsMoves" => [0u8, 0x1Eu8],
+    "Supported" => [0u8, 0x20u8],
+    "SoftDelete" => [0u8, 0x21u8],
+    "MIMESupport" => [0u8, 0x22u8],
+    "MIMETruncation" => [0u8, 0x23u8],
+    "Wait" => [0u8, 0x24u8],
+    "Limit" => [0u8, 0x25u8],
+    "Partial" => [0u8, 0x26u8],
+    "ConversationMode" => [0u8, 0x27u8],
+    "MaxItems" => [0u8, 0x28u8],
+    "Contacts:Anniversary" => [1u8, 0x05u8],
+    "Contacts:AssistantName" => [1u8, 0x06u8],
+    "Contacts:AssistantPhoneNumber" => [1u8, 0x07u8],
+    "Contacts:Birthday" => [1u8, 0x08u8],
+    "Contacts:BusinessPhoneNumber" => [1u8, 0x13u8],
+    "Contacts:CompanyName" => [1u8, 0x19u8],
+    "Contacts:Email1Address" => [1u8, 0x1Bu8],
+    "Contacts:Email2Address" => [1u8, 0x1Cu8],
+    "Contacts:Email3Address" => [1u8, 0x1Du8],
+    "Contacts:FirstName" => [1u8, 0x1Fu8],
+    "Contacts:HomeCity" => [1u8, 0x21u8],
+    "Contacts:HomeCountry" => [1u8, 0x22u8],
+    "Contacts:HomePhoneNumber" => [1u8, 0x26u8],
+    "Contacts:LastName" => [1u8, 0x29u8],
+    "Contacts:MobilePhoneNumber" => [1u8, 0x2Bu8],
+    "Contacts:Suffix" => [1u8, 0x2Fu8],
+    "Contacts:Title" => [1u8, 0x30u8],
+    "Contacts:JobTitle" => [1u8, 0x33u8],
+    "Contacts:MiddleName" => [1u8, 0x35u8],
+    "Contacts:NickName" => [1u8, 0x37u8],
+    "Contacts:OfficeLocation" => [1u8, 0x39u8],
+    "Contacts:WebPage" => [1u8, 0x45u8],
+    "Contacts:YomiCompanyName" => [1u8, 0x47u8],
+    "Contacts:YomiFirstName" => [1u8, 0x48u8],
+    "Contacts:YomiLastName" => [1u8, 0x49u8],
+    "Email:Attachment" => [2u8, 0x05u8],
+    "Email:Attachments" => [2u8, 0x06u8],
+    "Email:AttName" => [2u8, 0x07u8],
+    "Email:AttSize" => [2u8, 0x08u8],
+    "Email:Body" => [2u8, 0x0Cu8],
+    "Email:DateReceived" => [2u8, 0x0Eu8],
+    "Email:DisplayTo" => [2u8, 0x11u8],
+    "Email:Subject" => [2u8, 0x14u8],
+    "Email:Read" => [2u8, 0x15u8],
+    "Email:To" => [2u8, 0x16u8],
+    "Email:Cc" => [2u8, 0x17u8],
+    "Email:From" => [2u8, 0x18u8],
+    "Email:Reply-To" => [2u8, 0x19u8],
+    "Email:AllDayEvent" => [2u8, 0x1Au8],
+    "Email:Categories" => [2u8, 0x1Bu8],
+    "Email:Category" => [2u8, 0x1Cu8],
+    "Email:DtStamp" => [2u8, 0x1Du8],
+    "Email:EndTime" => [2u8, 0x1Eu8],
+    "Email:InstanceType" => [2u8, 0x1Fu8],
+    "Email:BusyStatus" => [2u8, 0x20u8],
+    "Email:Location" => [2u8, 0x24u8],
+    "Email:MeetingRequest" => [2u8, 0x25u8],
+    "Email:Organizer" => [2u8, 0x26u8],
+    "Email:Recurrence" => [2u8, 0x28u8],
+    "Email:Reminder" => [2u8, 0x2Bu8],
+    "Email:RequiredAttendees" => [2u8, 0x2Cu8],
+    "Email:OptionalAttendees" => [2u8, 0x2Du8],
+    "Email:ResourceAttendees" => [2u8, 0x2Eu8],
+    "Email:ResponseRequested" => [2u8, 0x2Fu8],
+    "Email:Sensitivity" => [2u8, 0x30u8],
+    "Email:StartTime" => [2u8, 0x31u8],
+    "Email:Timezone" => [2u8, 0x32u8],
+    "Email:GlobalObjId" => [2u8, 0x33u8],
+    "Email:ThreadTopic" => [2u8, 0x34u8],
+    "Email:InternetCPID" => [2u8, 0x39u8],
+    "Email:Flag" => [2u8, 0x3Au8],
+    "Email:FlagStatus" => [2u8, 0x3Bu8],
+    "Email:ContentClass" => [2u8, 0x3Cu8],
+    "Email:FlagType" => [2u8, 0x3Du8],
+    "Email:CompleteTime" => [2u8, 0x3Eu8],
+    "Email:DisallowNewTimeProposal" => [2u8, 0x40u8],
+    "Calendar:Timezone" => [4u8, 0x05u8],
+    "Calendar:AllDayEvent" => [4u8, 0x06u8],
+    "Calendar:Attendees" => [4u8, 0x07u8],
+    "Calendar:Attendee" => [4u8, 0x08u8],
+    "Calendar:Email" => [4u8, 0x09u8],
+    "Calendar:Name" => [4u8, 0x0Au8],
+    "Calendar:Body" => [4u8, 0x0Bu8],
+    "Calendar:BusyStatus" => [4u8, 0x0Du8],
+    "Calendar:Categories" => [4u8, 0x0Eu8],
+    "Calendar:Category" => [4u8, 0x0Fu8],
+    "Calendar:DtStamp" => [4u8, 0x11u8],
+    "Calendar:EndTime" => [4u8, 0x12u8],
+    "Calendar:Exception" => [4u8, 0x13u8],
+    "Calendar:Exceptions" => [4u8, 0x14u8],
+    "Calendar:Deleted" => [4u8, 0x15u8],
+    "Calendar:ExceptionStartTime" => [4u8, 0x16u8],
+    "Calendar:Location" => [4u8, 0x17u8],
+    "Calendar:MeetingStatus" => [4u8, 0x18u8],
+    "Calendar:OrganizerEmail" => [4u8, 0x19u8],
+    "Calendar:OrganizerName" => [4u8, 0x1Au8],
+    "Calendar:Recurrence" => [4u8, 0x1Bu8],
+    "Calendar:Type" => [4u8, 0x1Cu8],
+    "Calendar:Until" => [4u8, 0x1Du8],
+    "Calendar:Occurrences" => [4u8, 0x1Eu8],
+    "Calendar:Interval" => [4u8, 0x1Fu8],
+    "Calendar:DayOfWeek" => [4u8, 0x20u8],
+    "Calendar:DayOfMonth" => [4u8, 0x21u8],
+    "Calendar:WeekOfMonth" => [4u8, 0x22u8],
+    "Calendar:MonthOfYear" => [4u8, 0x23u8],
+    "Calendar:Reminder" => [4u8, 0x24u8],
+    "Calendar:Sensitivity" => [4u8, 0x25u8],
+    "Calendar:Subject" => [4u8, 0x26u8],
+    "Calendar:StartTime" => [4u8, 0x27u8],
+    "Calendar:UID" => [4u8, 0x28u8],
+    "Calendar:AttendeeStatus" => [4u8, 0x29u8],
+    "Calendar:AttendeeType" => [4u8, 0x2Au8],
+    "Calendar:DisallowNewTimeProposal" => [4u8, 0x33u8],
+    "Calendar:ResponseRequested" => [4u8, 0x34u8],
+    "Calendar:AppointmentReplyTime" => [4u8, 0x35u8],
+    "Calendar:ResponseType" => [4u8, 0x36u8],
+    "Calendar:CalendarType" => [4u8, 0x37u8],
+    "Calendar:IsLeapMonth" => [4u8, 0x38u8],
+    "Calendar:FirstDayOfWeek" => [4u8, 0x39u8],
+    "Calendar:OnlineMeetingConfLink" => [4u8, 0x3Au8],
+    "Calendar:OnlineMeetingExternalLink" => [4u8, 0x3Bu8],
+    "Calendar:ClientUid" => [4u8, 0x3Cu8],
+    "Calendar:StartTimeZoneId" => [4u8, 0x3Du8],
+    "Calendar:StartTimeZone" => [4u8, 0x3Eu8],
+    "Calendar:EndTimeZone" => [4u8, 0x3Fu8],
+    "Calendar:EndTimeZoneId" => [4u8, 0x40u8],
+    "MoveItems" => [5u8, 0x05u8],
+    "SrcMsgId" => [5u8, 0x07u8],
+    "SrcFldId" => [5u8, 0x08u8],
+    "MoveResponse" => [5u8, 0x0Au8],
+    "MoveStatus" => [5u8, 0x0Bu8],
+    "GetItemEstimate" => [6u8, 0x05u8],
+    "GIEVersion" => [6u8, 0x06u8],
+    "GIECollections" => [6u8, 0x07u8],
+    "GIECollection" => [6u8, 0x08u8],
+    "GIEClass" => [6u8, 0x09u8],
+    "GIECollectionId" => [6u8, 0x0Au8],
+    "DateTime" => [6u8, 0x0Bu8],
+    "Estimate" => [6u8, 0x0Cu8],
+    "ServerId" => [7u8, 0x08u8],
+    "ParentId" => [7u8, 0x09u8],
+    "Changes" => [7u8, 0x0Eu8],
+    "Add" => [7u8, 0x0Fu8],
+    "Delete" => [7u8, 0x10u8],
+    "Update" => [7u8, 0x11u8],
+    "SyncKey" => [7u8, 0x12u8],
+    "FolderCreate" => [7u8, 0x13u8],
+    "FolderDelete" => [7u8, 0x14u8],
+    "FolderUpdate" => [7u8, 0x15u8],
+    "FolderSync" => [7u8, 0x16u8],
+    "Count" => [7u8, 0x17u8],
+    "CalendarId" => [8u8, 0x05u8],
+    "MeetingCollectionId" => [8u8, 0x06u8],
+    "MeetingResponse" => [8u8, 0x07u8],
+    "RequestId" => [8u8, 0x08u8],
+    "Request" => [8u8, 0x09u8],
+    "UserResponse" => [8u8, 0x0Cu8],
+    "InstanceId" => [8u8, 0x0Eu8],
+    "ProposedStartTime" => [8u8, 0x10u8],
+    "ProposedEndTime" => [8u8, 0x11u8],
+    "SendResponse" => [8u8, 0x12u8],
+    "Tasks:Complete" => [9u8, 0x08u8],
+    "Tasks:DateCompleted" => [9u8, 0x09u8],
+    "Tasks:DueDate" => [9u8, 0x0Du8],
+    "Tasks:Importance" => [9u8, 0x0Fu8],
+    "Tasks:StartDate" => [9u8, 0x17u8],
+    "Tasks:Subject" => [9u8, 0x18u8],
+    "Tasks:ReminderSet" => [9u8, 0x19u8],
+    "Tasks:ReminderTime" => [9u8, 0x1Au8],
+    "Tasks:Sensitivity" => [9u8, 0x1Bu8],
+    "Tasks:Recurrence" => [9u8, 0x1Cu8],
+    "Tasks:Type" => [9u8, 0x1Du8],
+    "Tasks:Start" => [9u8, 0x1Eu8],
+    "Tasks:Until" => [9u8, 0x1Fu8],
+    "Tasks:Occurrences" => [9u8, 0x20u8],
+    "Tasks:Interval" => [9u8, 0x21u8],
+    "Tasks:DayOfWeek" => [9u8, 0x22u8],
+    "Tasks:DayOfMonth" => [9u8, 0x23u8],
+    "Tasks:WeekOfMonth" => [9u8, 0x24u8],
+    "Tasks:MonthOfYear" => [9u8, 0x25u8],
+    "Tasks:Regenerate" => [9u8, 0x26u8],
+    "Tasks:DeadOccur" => [9u8, 0x27u8],
+    "Tasks:Categories" => [9u8, 0x28u8],
+    "Tasks:Category" => [9u8, 0x29u8],
+    "ResolveRecipients" => [10u8, 0x05u8],
+    "Type" => [10u8, 0x08u8],
+    "Recipient" => [10u8, 0x09u8],
+    "DisplayName" => [10u8, 0x0Au8],
+    "EmailAddress" => [10u8, 0x0Bu8],
+    "MiniCertificate" => [10u8, 0x0Eu8],
+    "To" => [10u8, 0x10u8],
+    "CertificateRetrieval" => [10u8, 0x11u8],
+    "RecipientCount" => [10u8, 0x12u8],
+    "MaxCertificates" => [10u8, 0x13u8],
+    "MaxAmbiguousRecipients" => [10u8, 0x14u8],
+    "CertificateCount" => [10u8, 0x15u8],
+    "Availability" => [10u8, 0x16u8],
+    "MergedFreeBusy" => [10u8, 0x19u8],
+    "Picture" => [10u8, 0x1Au8],
+    "MaxSize" => [10u8, 0x1Bu8],
+    "MaxPictures" => [10u8, 0x1Du8],
+    "ValidateCert" => [11u8, 0x05u8],
+    "Certificates" => [11u8, 0x06u8],
+    "Certificate" => [11u8, 0x07u8],
+    "CertificateChain" => [11u8, 0x08u8],
+    "CheckCRL" => [11u8, 0x09u8],
+    "CertificateStatus" => [11u8, 0x0Au8],
+    "Contacts2:CustomerId" => [12u8, 0x05u8],
+    "Contacts2:GovernmentId" => [12u8, 0x06u8],
+    "Contacts2:IMAddress" => [12u8, 0x07u8],
+    "Contacts2:IMAddress2" => [12u8, 0x08u8],
+    "Contacts2:IMAddress3" => [12u8, 0x09u8],
+    "Contacts2:ManagerName" => [12u8, 0x0Au8],
+    "Contacts2:CompanyMainPhone" => [12u8, 0x0Bu8],
+    "Contacts2:AccountName" => [12u8, 0x0Cu8],
+    "Contacts2:MMS" => [12u8, 0x0Du8],
+    "Contacts2:NickName" => [12u8, 0x0Eu8],
+    "Ping" => [13u8, 0x05u8],
+    "HeartbeatInterval" => [13u8, 0x08u8],
+    "Folders" => [13u8, 0x09u8],
+    "Folder" => [13u8, 0x0Au8],
+    "Id" => [13u8, 0x0Bu8],
+    "MaxFolders" => [13u8, 0x0Du8],
+    "Provision" => [14u8, 0x05u8],
+    "Policies" => [14u8, 0x06u8],
+    "Policy" => [14u8, 0x07u8],
+    "PolicyType" => [14u8, 0x08u8],
+    "PolicyKey" => [14u8, 0x09u8],
+    "RemoteWipe" => [14u8, 0x0Cu8],
+    "EASProvisionDoc" => [14u8, 0x0Du8],
+    "DevicePasswordEnabled" => [14u8, 0x0Eu8],
+    "AlphanumericDevicePasswordRequired" => [14u8, 0x0Fu8],
+    "RequireStorageCardEncryption" => [14u8, 0x10u8],
+    "PasswordRecoveryEnabled" => [14u8, 0x11u8],
+    "AttachmentsEnabled" => [14u8, 0x13u8],
+    "MinDevicePasswordLength" => [14u8, 0x14u8],
+    "MaxInactivityTimeDeviceLock" => [14u8, 0x15u8],
+    "MaxDevicePasswordFailedAttempts" => [14u8, 0x16u8],
+    "MaxAttachmentSize" => [14u8, 0x17u8],
+    "AllowSimpleDevicePassword" => [14u8, 0x18u8],
+    "DevicePasswordExpiration" => [14u8, 0x19u8],
+    "DevicePasswordHistory" => [14u8, 0x1Au8],
+    "AllowStorageCard" => [14u8, 0x1Bu8],
+    "AllowCamera" => [14u8, 0x1Cu8],
+    "RequireDeviceEncryption" => [14u8, 0x1Du8],
+    "AllowUnsignedApplications" => [14u8, 0x1Eu8],
+    "AllowUnsignedInstallationPackages" => [14u8, 0x1Fu8],
+    "MinDevicePasswordComplexCharacters" => [14u8, 0x20u8],
+    "AllowWifi" => [14u8, 0x21u8],
+    "AllowTextMessaging" => [14u8, 0x22u8],
+    "AllowPOPIMAPEmail" => [14u8, 0x23u8],
+    "AllowBluetooth" => [14u8, 0x24u8],
+    "AllowIrDA" => [14u8, 0x25u8],
+    "RequireManualSyncWhenRoaming" => [14u8, 0x26u8],
+    "AllowDesktopSync" => [14u8, 0x27u8],
+    "MaxCalendarAgeFilter" => [14u8, 0x28u8],
+    "AllowHTMLEmail" => [14u8, 0x29u8],
+    "MaxEmailAgeFilter" => [14u8, 0x2Au8],
+    "MaxEmailBodyTruncationSize" => [14u8, 0x2Bu8],
+    "MaxEmailHTMLBodyTruncationSize" => [14u8, 0x2Cu8],
+    "RequireSignedSMIMEMessages" => [14u8, 0x2Du8],
+    "RequireEncryptedSMIMEMessages" => [14u8, 0x2Eu8],
+    "RequireSignedSMIMEAlgorithm" => [14u8, 0x2Fu8],
+    "RequireEncryptionSMIMEAlgorithm" => [14u8, 0x30u8],
+    "AllowSMIMEEncryptionAlgorithmNegotiation" => [14u8, 0x31u8],
+    "AllowSMIMESoftCerts" => [14u8, 0x32u8],
+    "AllowBrowser" => [14u8, 0x33u8],
+    "AllowConsumerEmail" => [14u8, 0x34u8],
+    "AllowRemoteDesktop" => [14u8, 0x35u8],
+    "AllowInternetSharing" => [14u8, 0x36u8],
+    "UnapprovedInROMApplicationList" => [14u8, 0x37u8],
+    "ApplicationName" => [14u8, 0x38u8],
+    "ApprovedApplicationList" => [14u8, 0x39u8],
+    "Hash" => [14u8, 0x3Au8],
+    "Search" => [15u8, 0x05u8],
+    "Name" => [15u8, 0x08u8],
+    "Query" => [15u8, 0x09u8],
+    "Result" => [15u8, 0x0Eu8],
+    "EqualTo" => [15u8, 0x11u8],
+    "Value" => [15u8, 0x12u8],
+    "And" => [15u8, 0x13u8],
+    "Or" => [15u8, 0x14u8],
+    "FreeText" => [15u8, 0x15u8],
+    "DeepTraversal" => [15u8, 0x17u8],
+    "LongId" => [15u8, 0x18u8],
+    "RebuildResults" => [15u8, 0x19u8],
+    "LeafName" => [15u8, 0x1Au8],
+    "Class" => [15u8, 0x1Bu8],
+    "CollectionId" => [15u8, 0x1Cu8],
+    "QueryId" => [15u8, 0x1Du8],
+    "MaxResults" => [15u8, 0x1Eu8],
+    "GAL:DisplayName" => [16u8, 0x05u8],
+    "GAL:Phone" => [16u8, 0x06u8],
+    "GAL:Office" => [16u8, 0x07u8],
+    "GAL:Title" => [16u8, 0x08u8],
+    "GAL:Company" => [16u8, 0x09u8],
+    "GAL:Alias" => [16u8, 0x0Au8],
+    "GAL:FirstName" => [16u8, 0x0Bu8],
+    "GAL:LastName" => [16u8, 0x0Cu8],
+    "GAL:HomePhone" => [16u8, 0x0Du8],
+    "GAL:MobilePhone" => [16u8, 0x0Eu8],
+    "GAL:EmailAddress" => [16u8, 0x0Fu8],
+    "GAL:Picture" => [16u8, 0x10u8],
+    "GAL:Status" => [16u8, 0x11u8],
+    "GAL:Data" => [16u8, 0x12u8],
+    "AirSyncBase:BodyPreference" => [17u8, 0x05u8],
+    "AirSyncBase:Type" => [17u8, 0x06u8],
+    "AirSyncBase:TruncationSize" => [17u8, 0x07u8],
+    "AirSyncBase:AllOrNone" => [17u8, 0x08u8],
+    "AirSyncBase:Body" => [17u8, 0x0Au8],
+    "AirSyncBase:Data" => [17u8, 0x0Bu8],
+    "AirSyncBase:EstimatedDataSize" => [17u8, 0x0Cu8],
+    "AirSyncBase:Truncated" => [17u8, 0x0Du8],
+    "AirSyncBase:Attachments" => [17u8, 0x0Eu8],
+    "AirSyncBase:Attachment" => [17u8, 0x0Fu8],
+    "AirSyncBase:DisplayName" => [17u8, 0x10u8],
+    "AirSyncBase:FileReference" => [17u8, 0x11u8],
+    "AirSyncBase:Method" => [17u8, 0x12u8],
+    "AirSyncBase:ContentId" => [17u8, 0x13u8],
+    "AirSyncBase:ContentLocation" => [17u8, 0x14u8],
+    "AirSyncBase:IsInline" => [17u8, 0x15u8],
+    "AirSyncBase:NativeBodyType" => [17u8, 0x16u8],
+    "AirSyncBase:ContentType" => [17u8, 0x17u8],
+    "AirSyncBase:Preview" => [17u8, 0x18u8],
+    "AirSyncBase:BodyPartPreference" => [17u8, 0x19u8],
+    "AirSyncBase:BodyPart" => [17u8, 0x1Au8],
+    "AirSyncBase:Status" => [17u8, 0x1Bu8],
+    "AirSyncBase:Add" => [17u8, 0x1Cu8],
+    "AirSyncBase:Delete" => [17u8, 0x1Du8],
+    "AirSyncBase:ClientId" => [17u8, 0x1Eu8],
+    "AirSyncBase:Content" => [17u8, 0x1Fu8],
+    "AirSyncBase:Location" => [17u8, 0x20u8],
+    "AirSyncBase:Annotation" => [17u8, 0x21u8],
+    "AirSyncBase:Street" => [17u8, 0x22u8],
+    "AirSyncBase:City" => [17u8, 0x23u8],
+    "AirSyncBase:State" => [17u8, 0x24u8],
+    "AirSyncBase:Country" => [17u8, 0x25u8],
+    "AirSyncBase:PostalCode" => [17u8, 0x26u8],
+    "AirSyncBase:Latitude" => [17u8, 0x27u8],
+    "AirSyncBase:Longitude" => [17u8, 0x28u8],
+    "AirSyncBase:Accuracy" => [17u8, 0x29u8],
+    "AirSyncBase:Altitude" => [17u8, 0x2Au8],
+    "AirSyncBase:AltitudeAccuracy" => [17u8, 0x2Bu8],
+    "AirSyncBase:LocationUri" => [17u8, 0x2Cu8],
+    "AirSyncBase:InstanceId" => [17u8, 0x2Du8],
+    "Settings" => [18u8, 0x05u8],
+    "Get" => [18u8, 0x07u8],
+    "Set" => [18u8, 0x08u8],
+    "Oof" => [18u8, 0x09u8],
+    "OofState" => [18u8, 0x0Au8],
+    "StartTime" => [18u8, 0x0Bu8],
+    "EndTime" => [18u8, 0x0Cu8],
+    "OofMessage" => [18u8, 0x0Du8],
+    "AppliesToInternal" => [18u8, 0x0Eu8],
+    "AppliesToExternalKnown" => [18u8, 0x0Fu8],
+    "AppliesToExternalUnknown" => [18u8, 0x10u8],
+    "Enabled" => [18u8, 0x11u8],
+    "ReplyMessage" => [18u8, 0x12u8],
+    "BodyType" => [18u8, 0x13u8],
+    "DevicePassword" => [18u8, 0x14u8],
+    "Password" => [18u8, 0x15u8],
+    "DeviceInformation" => [18u8, 0x16u8],
+    "Model" => [18u8, 0x17u8],
+    "IMEI" => [18u8, 0x18u8],
+    "FriendlyName" => [18u8, 0x19u8],
+    "OS" => [18u8, 0x1Au8],
+    "OSLanguage" => [18u8, 0x1Bu8],
+    "PhoneNumber" => [18u8, 0x1Cu8],
+    "UserInformation" => [18u8, 0x1Du8],
+    "EmailAddresses" => [18u8, 0x1Eu8],
+    "SMTPAddress" => [18u8, 0x1Fu8],
+    "UserAgent" => [18u8, 0x20u8],
+    "EnableOutboundSMS" => [18u8, 0x21u8],
+    "MobileOperator" => [18u8, 0x22u8],
+    "PrimarySmtpAddress" => [18u8, 0x23u8],
+    "Accounts" => [18u8, 0x24u8],
+    "Account" => [18u8, 0x25u8],
+    "AccountName" => [18u8, 0x27u8],
+    "UserDisplayName" => [18u8, 0x28u8],
+    "SendDisabled" => [18u8, 0x29u8],
+    "RightsManagementInformation" => [18u8, 0x2Bu8],
+    "DocumentLibrary:LinkId" => [19u8, 0x05u8],
+    "DocumentLibrary:DisplayName" => [19u8, 0x06u8],
+    "DocumentLibrary:IsFolder" => [19u8, 0x07u8],
+    "DocumentLibrary:CreationDate" => [19u8, 0x08u8],
+    "DocumentLibrary:LastModifiedDate" => [19u8, 0x09u8],
+    "DocumentLibrary:IsHidden" => [19u8, 0x0Au8],
+    "DocumentLibrary:ContentLength" => [19u8, 0x0Bu8],
+    "DocumentLibrary:ContentType" => [19u8, 0x0Cu8],
+    "ItemOperations" => [20u8, 0x05u8],
+    "Fetch" => [20u8, 0x06u8],
+    "Store" => [20u8, 0x07u8],
+    "Options" => [20u8, 0x08u8],
+    "Range" => [20u8, 0x09u8],
+    "Total" => [20u8, 0x0Au8],
+    "Properties" => [20u8, 0x0Bu8],
+    "Data" => [20u8, 0x0Cu8],
+    "Response" => [20u8, 0x0Eu8],
+    "Version" => [20u8, 0x0Fu8],
+    "Schema" => [20u8, 0x10u8],
+    "Part" => [20u8, 0x11u8],
+    "EmptyFolderContents" => [20u8, 0x12u8],
+    "DeleteSubFolders" => [20u8, 0x13u8],
+    "UserName" => [20u8, 0x14u8],
+    "IOPassword" => [20u8, 0x15u8],
+    "Move" => [20u8, 0x16u8],
+    "DstFldId" => [20u8, 0x17u8],
+    "ConversationId" => [20u8, 0x18u8],
+    "MoveAlways" => [20u8, 0x19u8],
+    "SendMail" => [21u8, 0x05u8],
+    "SmartForward" => [21u8, 0x06u8],
+    "SmartReply" => [21u8, 0x07u8],
+    "SaveInSentItems" => [21u8, 0x08u8],
+    "ReplaceMime" => [21u8, 0x09u8],
+    "Mime" => [21u8, 0x0Bu8],
+    "ClientId" => [21u8, 0x0Cu8],
+    "Status" => [21u8, 0x0Du8],
+    "AccountId" => [21u8, 0x0Eu8],
+    "Forwardees" => [21u8, 0x0Fu8],
+    "Forwardee" => [21u8, 0x10u8],
+    "ForwardeeName" => [21u8, 0x11u8],
+    "ForwardeeEmail" => [21u8, 0x12u8],
+    "Email2:UmCallerId" => [22u8, 0x05u8],
+    "Email2:UmUserNotes" => [22u8, 0x06u8],
+    "Email2:UmAttDuration" => [22u8, 0x07u8],
+    "Email2:UmAttOrder" => [22u8, 0x08u8],
+    "Email2:ConversationId" => [22u8, 0x09u8],
+    "Email2:ConversationIndex" => [22u8, 0x0Au8],
+    "Email2:LastVerbExecuted" => [22u8, 0x0Bu8],
+    "Email2:LastVerbExecutionTime" => [22u8, 0x0Cu8],
+    "Email2:ReceivedAsBcc" => [22u8, 0x0Du8],
+    "Email2:Sender" => [22u8, 0x0Eu8],
+    "Email2:CalendarType" => [22u8, 0x0Fu8],
+    "Email2:IsLeapMonth" => [22u8, 0x10u8],
+    "Email2:AccountId" => [22u8, 0x11u8],
+    "Email2:FirstDayOfWeek" => [22u8, 0x12u8],
+    "Email2:MeetingMessageType" => [22u8, 0x13u8],
+    "Notes:Subject" => [23u8, 0x05u8],
+    "Notes:MessageClass" => [23u8, 0x06u8],
+    "Notes:LastModifiedDate" => [23u8, 0x07u8],
+    "Notes:Categories" => [23u8, 0x08u8],
+    "Notes:Category" => [23u8, 0x09u8],
+    "Notes:Body" => [23u8, 0x0Bu8],
+    "RightsManagement:RightsManagementSupport" => [24u8, 0x05u8],
+    "RightsManagement:RightsManagementTemplates" => [24u8, 0x06u8],
+    "RightsManagement:RightsManagementTemplate" => [24u8, 0x07u8],
+    "RightsManagement:RightsManagementLicense" => [24u8, 0x08u8],
+    "RightsManagement:EditAllowed" => [24u8, 0x09u8],
+    "RightsManagement:ReplyAllowed" => [24u8, 0x0Au8],
+    "RightsManagement:ReplyAllAllowed" => [24u8, 0x0Bu8],
+    "RightsManagement:ForwardAllowed" => [24u8, 0x0Cu8],
+    "RightsManagement:ModifyRecipientsAllowed" => [24u8, 0x0Du8],
+    "RightsManagement:ExtractAllowed" => [24u8, 0x0Eu8],
+    "RightsManagement:PrintAllowed" => [24u8, 0x0Fu8],
+    "RightsManagement:ExportAllowed" => [24u8, 0x10u8],
+    "RightsManagement:ProgrammaticAccessAllowed" => [24u8, 0x11u8],
+    "RightsManagement:RMOwner" => [24u8, 0x12u8],
+    "RightsManagement:ContentExpiryDate" => [24u8, 0x13u8],
+    "RightsManagement:ContentExpiryDateString" => [24u8, 0x14u8],
+    "RightsManagement:ContentExpiryInterval" => [24u8, 0x15u8],
+    "RightsManagement:ContentExpiryIntervalType" => [24u8, 0x16u8],
+    "RightsManagement:TemplateID" => [24u8, 0x17u8],
+    "RightsManagement:TemplateName" => [24u8, 0x18u8],
+    "RightsManagement:TemplateDescription" => [24u8, 0x19u8],
+    "RightsManagement:ContentOwner" => [24u8, 0x1Au8],
+    "RightsManagement:RemoveRightsManagementDistribution" => [24u8, 0x1Bu8],
+};
 
 fn namespace_to_code_page(ns: &str) -> Option<u8> {
     match ns {
@@ -50,15 +1050,15 @@ fn namespace_to_code_page(ns: &str) -> Option<u8> {
 fn find_encode_tag(qualified_or_local: &str, override_cp: Option<u8>) -> Option<(u8, u8)> {
     if let Some(&pair) = NAME_TO_TAG.get(qualified_or_local) {
         if let Some(cp) = override_cp {
-            if pair.0 == cp {
-                return Some(pair);
+            if pair[0] == cp {
+                return Some((pair[0], pair[1]));
             }
         } else {
-            return Some(pair);
+            return Some((pair[0], pair[1]));
         }
     }
 
-    for (&(cp, id), &name) in TAG_TO_NAME.iter() {
+    for (&pair, &name) in TAG_TO_NAME.entries() {
         let local = if let Some(p) = name.rfind(':') {
             &name[p + 1..]
         } else {
@@ -66,568 +1066,15 @@ fn find_encode_tag(qualified_or_local: &str, override_cp: Option<u8>) -> Option<
         };
         if local == qualified_or_local {
             if let Some(ocp) = override_cp {
-                if cp == ocp {
-                    return Some((cp, id));
+                if pair[0] == ocp {
+                    return Some((pair[0], pair[1]));
                 }
             } else {
-                return Some((cp, id));
+                return Some((pair[0], pair[1]));
             }
         }
     }
     None
-}
-
-#[rustfmt::skip]
-fn build_tag_to_name() -> HashMap<(u8, u8), &'static str> {
-    let mut m: HashMap<(u8, u8), &'static str> = HashMap::new();
-
-    m.insert((0, 0x05), "Sync");
-    m.insert((0, 0x06), "Responses");
-    m.insert((0, 0x07), "Add");
-    m.insert((0, 0x08), "Change");
-    m.insert((0, 0x09), "Delete");
-    m.insert((0, 0x0A), "Fetch");
-    m.insert((0, 0x0B), "SyncKey");
-    m.insert((0, 0x0C), "ClientId");
-    m.insert((0, 0x0D), "ServerId");
-    m.insert((0, 0x0E), "Status");
-    m.insert((0, 0x0F), "Collection");
-    m.insert((0, 0x10), "Class");
-    m.insert((0, 0x12), "CollectionId");
-    m.insert((0, 0x13), "GetChanges");
-    m.insert((0, 0x14), "MoreAvailable");
-    m.insert((0, 0x15), "WindowSize");
-    m.insert((0, 0x16), "Commands");
-    m.insert((0, 0x17), "Options");
-    m.insert((0, 0x18), "FilterType");
-    m.insert((0, 0x1B), "Conflict");
-    m.insert((0, 0x1C), "Collections");
-    m.insert((0, 0x1D), "ApplicationData");
-    m.insert((0, 0x1E), "DeletesAsMoves");
-    m.insert((0, 0x20), "Supported");
-    m.insert((0, 0x21), "SoftDelete");
-    m.insert((0, 0x22), "MIMESupport");
-    m.insert((0, 0x23), "MIMETruncation");
-    m.insert((0, 0x24), "Wait");
-    m.insert((0, 0x25), "Limit");
-    m.insert((0, 0x26), "Partial");
-    m.insert((0, 0x27), "ConversationMode");
-    m.insert((0, 0x28), "MaxItems");
-    m.insert((0, 0x29), "HeartbeatInterval");
-
-    m.insert((1, 0x05), "Contacts:Anniversary");
-    m.insert((1, 0x06), "Contacts:AssistantName");
-    m.insert((1, 0x07), "Contacts:AssistantPhoneNumber");
-    m.insert((1, 0x08), "Contacts:Birthday");
-    m.insert((1, 0x13), "Contacts:BusinessPhoneNumber");
-    m.insert((1, 0x19), "Contacts:CompanyName");
-    m.insert((1, 0x1B), "Contacts:Email1Address");
-    m.insert((1, 0x1C), "Contacts:Email2Address");
-    m.insert((1, 0x1D), "Contacts:Email3Address");
-    m.insert((1, 0x1F), "Contacts:FirstName");
-    m.insert((1, 0x21), "Contacts:HomeCity");
-    m.insert((1, 0x22), "Contacts:HomeCountry");
-    m.insert((1, 0x26), "Contacts:HomePhoneNumber");
-    m.insert((1, 0x29), "Contacts:LastName");
-    m.insert((1, 0x2B), "Contacts:MobilePhoneNumber");
-    m.insert((1, 0x2F), "Contacts:Suffix");
-    m.insert((1, 0x30), "Contacts:Title");
-    m.insert((1, 0x33), "Contacts:JobTitle");
-    m.insert((1, 0x35), "Contacts:MiddleName");
-    m.insert((1, 0x37), "Contacts:NickName");
-    m.insert((1, 0x39), "Contacts:OfficeLocation");
-    m.insert((1, 0x45), "Contacts:WebPage");
-    m.insert((1, 0x47), "Contacts:YomiCompanyName");
-    m.insert((1, 0x48), "Contacts:YomiFirstName");
-    m.insert((1, 0x49), "Contacts:YomiLastName");
-
-    m.insert((2, 0x05), "Email:Attachment");
-    m.insert((2, 0x06), "Email:Attachments");
-    m.insert((2, 0x07), "Email:AttName");
-    m.insert((2, 0x08), "Email:AttSize");
-    m.insert((2, 0x0C), "Email:Body");
-    m.insert((2, 0x0E), "Email:DateReceived");
-    m.insert((2, 0x11), "Email:DisplayTo");
-    m.insert((2, 0x14), "Email:Subject");
-    m.insert((2, 0x15), "Email:Read");
-    m.insert((2, 0x16), "Email:To");
-    m.insert((2, 0x17), "Email:Cc");
-    m.insert((2, 0x18), "Email:From");
-    m.insert((2, 0x19), "Email:Reply-To");
-    m.insert((2, 0x1A), "Email:AllDayEvent");
-    m.insert((2, 0x1B), "Email:Categories");
-    m.insert((2, 0x1C), "Email:Category");
-    m.insert((2, 0x1D), "Email:DtStamp");
-    m.insert((2, 0x1E), "Email:EndTime");
-    m.insert((2, 0x1F), "Email:InstanceType");
-    m.insert((2, 0x20), "Email:BusyStatus");
-    m.insert((2, 0x24), "Email:Location");
-    m.insert((2, 0x25), "Email:MeetingRequest");
-    m.insert((2, 0x26), "Email:Organizer");
-    m.insert((2, 0x28), "Email:Recurrence");
-    m.insert((2, 0x2B), "Email:Reminder");
-    m.insert((2, 0x2C), "Email:RequiredAttendees");
-    m.insert((2, 0x2D), "Email:OptionalAttendees");
-    m.insert((2, 0x2E), "Email:ResourceAttendees");
-    m.insert((2, 0x2F), "Email:ResponseRequested");
-    m.insert((2, 0x30), "Email:Sensitivity");
-    m.insert((2, 0x31), "Email:StartTime");
-    m.insert((2, 0x32), "Email:Timezone");
-    m.insert((2, 0x33), "Email:GlobalObjId");
-    m.insert((2, 0x34), "Email:ThreadTopic");
-    m.insert((2, 0x39), "Email:InternetCPID");
-    m.insert((2, 0x3A), "Email:Flag");
-    m.insert((2, 0x3B), "Email:FlagStatus");
-    m.insert((2, 0x3C), "Email:ContentClass");
-    m.insert((2, 0x3D), "Email:FlagType");
-    m.insert((2, 0x3E), "Email:CompleteTime");
-    m.insert((2, 0x40), "Email:DisallowNewTimeProposal");
-
-    m.insert((4, 0x05), "Calendar:Timezone");
-    m.insert((4, 0x06), "Calendar:AllDayEvent");
-    m.insert((4, 0x07), "Calendar:Attendees");
-    m.insert((4, 0x08), "Calendar:Attendee");
-    m.insert((4, 0x09), "Calendar:Email");
-    m.insert((4, 0x0A), "Calendar:Name");
-    m.insert((4, 0x0B), "Calendar:Body");
-    m.insert((4, 0x0D), "Calendar:BusyStatus");
-    m.insert((4, 0x0E), "Calendar:Categories");
-    m.insert((4, 0x0F), "Calendar:Category");
-    m.insert((4, 0x11), "Calendar:DtStamp");
-    m.insert((4, 0x12), "Calendar:EndTime");
-    m.insert((4, 0x13), "Calendar:Exception");
-    m.insert((4, 0x14), "Calendar:Exceptions");
-    m.insert((4, 0x15), "Calendar:Deleted");
-    m.insert((4, 0x16), "Calendar:ExceptionStartTime");
-    m.insert((4, 0x17), "Calendar:Location");
-    m.insert((4, 0x18), "Calendar:MeetingStatus");
-    m.insert((4, 0x19), "Calendar:OrganizerEmail");
-    m.insert((4, 0x1A), "Calendar:OrganizerName");
-    m.insert((4, 0x1B), "Calendar:Recurrence");
-    m.insert((4, 0x1C), "Calendar:Type");
-    m.insert((4, 0x1D), "Calendar:Until");
-    m.insert((4, 0x1E), "Calendar:Occurrences");
-    m.insert((4, 0x1F), "Calendar:Interval");
-    m.insert((4, 0x20), "Calendar:DayOfWeek");
-    m.insert((4, 0x21), "Calendar:DayOfMonth");
-    m.insert((4, 0x22), "Calendar:WeekOfMonth");
-    m.insert((4, 0x23), "Calendar:MonthOfYear");
-    m.insert((4, 0x24), "Calendar:Reminder");
-    m.insert((4, 0x25), "Calendar:Sensitivity");
-    m.insert((4, 0x26), "Calendar:Subject");
-    m.insert((4, 0x27), "Calendar:StartTime");
-    m.insert((4, 0x28), "Calendar:UID");
-    m.insert((4, 0x29), "Calendar:AttendeeStatus");
-    m.insert((4, 0x2A), "Calendar:AttendeeType");
-    m.insert((4, 0x33), "Calendar:DisallowNewTimeProposal");
-    m.insert((4, 0x34), "Calendar:ResponseRequested");
-    m.insert((4, 0x35), "Calendar:AppointmentReplyTime");
-    m.insert((4, 0x36), "Calendar:ResponseType");
-    m.insert((4, 0x37), "Calendar:CalendarType");
-    m.insert((4, 0x38), "Calendar:IsLeapMonth");
-    m.insert((4, 0x39), "Calendar:FirstDayOfWeek");
-    m.insert((4, 0x3A), "Calendar:OnlineMeetingConfLink");
-    m.insert((4, 0x3B), "Calendar:OnlineMeetingExternalLink");
-    m.insert((4, 0x3C), "Calendar:ClientUid");
-    m.insert((4, 0x3D), "Calendar:StartTimeZoneId");
-    m.insert((4, 0x3E), "Calendar:StartTimeZone");
-    m.insert((4, 0x3F), "Calendar:EndTimeZone");
-    m.insert((4, 0x40), "Calendar:EndTimeZoneId");
-
-    m.insert((5, 0x05), "MoveItems");
-    m.insert((5, 0x06), "Move");
-    m.insert((5, 0x07), "SrcMsgId");
-    m.insert((5, 0x08), "SrcFldId");
-    m.insert((5, 0x09), "DstFldId");
-    m.insert((5, 0x0A), "MoveResponse");
-    m.insert((5, 0x0B), "MoveStatus");
-
-    m.insert((6, 0x05), "GetItemEstimate");
-    m.insert((6, 0x06), "GIEVersion");
-    m.insert((6, 0x07), "GIECollections");
-    m.insert((6, 0x08), "GIECollection");
-    m.insert((6, 0x09), "GIEClass");
-    m.insert((6, 0x0A), "GIECollectionId");
-    m.insert((6, 0x0B), "DateTime");
-    m.insert((6, 0x0C), "Estimate");
-    m.insert((6, 0x0D), "Response");
-    m.insert((6, 0x0E), "Status");
-
-    m.insert((7, 0x07), "DisplayName");
-    m.insert((7, 0x08), "ServerId");
-    m.insert((7, 0x09), "ParentId");
-    m.insert((7, 0x0A), "Type");
-    m.insert((7, 0x0C), "Status");
-    m.insert((7, 0x0E), "Changes");
-    m.insert((7, 0x0F), "Add");
-    m.insert((7, 0x10), "Delete");
-    m.insert((7, 0x11), "Update");
-    m.insert((7, 0x12), "SyncKey");
-    m.insert((7, 0x13), "FolderCreate");
-    m.insert((7, 0x14), "FolderDelete");
-    m.insert((7, 0x15), "FolderUpdate");
-    m.insert((7, 0x16), "FolderSync");
-    m.insert((7, 0x17), "Count");
-
-    m.insert((8, 0x05), "CalendarId");
-    m.insert((8, 0x06), "MeetingCollectionId");
-    m.insert((8, 0x07), "MeetingResponse");
-    m.insert((8, 0x08), "RequestId");
-    m.insert((8, 0x09), "Request");
-    m.insert((8, 0x0A), "Result");
-    m.insert((8, 0x0B), "Status");
-    m.insert((8, 0x0C), "UserResponse");
-    m.insert((8, 0x0E), "InstanceId");
-    m.insert((8, 0x0F), "LongId");
-    m.insert((8, 0x10), "ProposedStartTime");
-    m.insert((8, 0x11), "ProposedEndTime");
-    m.insert((8, 0x12), "SendResponse");
-
-    m.insert((9, 0x08), "Tasks:Complete");
-    m.insert((9, 0x09), "Tasks:DateCompleted");
-    m.insert((9, 0x0D), "Tasks:DueDate");
-    m.insert((9, 0x0F), "Tasks:Importance");
-    m.insert((9, 0x17), "Tasks:StartDate");
-    m.insert((9, 0x18), "Tasks:Subject");
-    m.insert((9, 0x19), "Tasks:ReminderSet");
-    m.insert((9, 0x1A), "Tasks:ReminderTime");
-    m.insert((9, 0x1B), "Tasks:Sensitivity");
-    m.insert((9, 0x1C), "Tasks:Recurrence");
-    m.insert((9, 0x1D), "Tasks:Type");
-    m.insert((9, 0x1E), "Tasks:Start");
-    m.insert((9, 0x1F), "Tasks:Until");
-    m.insert((9, 0x20), "Tasks:Occurrences");
-    m.insert((9, 0x21), "Tasks:Interval");
-    m.insert((9, 0x22), "Tasks:DayOfWeek");
-    m.insert((9, 0x23), "Tasks:DayOfMonth");
-    m.insert((9, 0x24), "Tasks:WeekOfMonth");
-    m.insert((9, 0x25), "Tasks:MonthOfYear");
-    m.insert((9, 0x26), "Tasks:Regenerate");
-    m.insert((9, 0x27), "Tasks:DeadOccur");
-    m.insert((9, 0x28), "Tasks:Categories");
-    m.insert((9, 0x29), "Tasks:Category");
-
-    m.insert((10, 0x05), "ResolveRecipients");
-    m.insert((10, 0x06), "Response");
-    m.insert((10, 0x07), "Status");
-    m.insert((10, 0x08), "Type");
-    m.insert((10, 0x09), "Recipient");
-    m.insert((10, 0x0A), "DisplayName");
-    m.insert((10, 0x0B), "EmailAddress");
-    m.insert((10, 0x0C), "Certificates");
-    m.insert((10, 0x0D), "Certificate");
-    m.insert((10, 0x0E), "MiniCertificate");
-    m.insert((10, 0x0F), "Options");
-    m.insert((10, 0x10), "To");
-    m.insert((10, 0x11), "CertificateRetrieval");
-    m.insert((10, 0x12), "RecipientCount");
-    m.insert((10, 0x13), "MaxCertificates");
-    m.insert((10, 0x14), "MaxAmbiguousRecipients");
-    m.insert((10, 0x15), "CertificateCount");
-    m.insert((10, 0x16), "Availability");
-    m.insert((10, 0x17), "StartTime");
-    m.insert((10, 0x18), "EndTime");
-    m.insert((10, 0x19), "MergedFreeBusy");
-    m.insert((10, 0x1A), "Picture");
-    m.insert((10, 0x1B), "MaxSize");
-    m.insert((10, 0x1C), "Data");
-    m.insert((10, 0x1D), "MaxPictures");
-
-    m.insert((11, 0x05), "ValidateCert");
-    m.insert((11, 0x06), "Certificates");
-    m.insert((11, 0x07), "Certificate");
-    m.insert((11, 0x08), "CertificateChain");
-    m.insert((11, 0x09), "CheckCRL");
-    m.insert((11, 0x0A), "CertificateStatus");
-    m.insert((11, 0x0B), "Status");
-
-    m.insert((12, 0x05), "Contacts2:CustomerId");
-    m.insert((12, 0x06), "Contacts2:GovernmentId");
-    m.insert((12, 0x07), "Contacts2:IMAddress");
-    m.insert((12, 0x08), "Contacts2:IMAddress2");
-    m.insert((12, 0x09), "Contacts2:IMAddress3");
-    m.insert((12, 0x0A), "Contacts2:ManagerName");
-    m.insert((12, 0x0B), "Contacts2:CompanyMainPhone");
-    m.insert((12, 0x0C), "Contacts2:AccountName");
-    m.insert((12, 0x0D), "Contacts2:MMS");
-    m.insert((12, 0x0E), "Contacts2:NickName");
-
-    m.insert((13, 0x05), "Ping");
-    m.insert((13, 0x07), "Status");
-    m.insert((13, 0x08), "HeartbeatInterval");
-    m.insert((13, 0x09), "Folders");
-    m.insert((13, 0x0A), "Folder");
-    m.insert((13, 0x0B), "Id");
-    m.insert((13, 0x0C), "Class");
-    m.insert((13, 0x0D), "MaxFolders");
-
-    m.insert((14, 0x05), "Provision");
-    m.insert((14, 0x06), "Policies");
-    m.insert((14, 0x07), "Policy");
-    m.insert((14, 0x08), "PolicyType");
-    m.insert((14, 0x09), "PolicyKey");
-    m.insert((14, 0x0A), "Data");
-    m.insert((14, 0x0B), "Status");
-    m.insert((14, 0x0C), "RemoteWipe");
-    m.insert((14, 0x0D), "EASProvisionDoc");
-    m.insert((14, 0x0E), "DevicePasswordEnabled");
-    m.insert((14, 0x0F), "AlphanumericDevicePasswordRequired");
-    m.insert((14, 0x10), "RequireStorageCardEncryption");
-    m.insert((14, 0x11), "PasswordRecoveryEnabled");
-    m.insert((14, 0x13), "AttachmentsEnabled");
-    m.insert((14, 0x14), "MinDevicePasswordLength");
-    m.insert((14, 0x15), "MaxInactivityTimeDeviceLock");
-    m.insert((14, 0x16), "MaxDevicePasswordFailedAttempts");
-    m.insert((14, 0x17), "MaxAttachmentSize");
-    m.insert((14, 0x18), "AllowSimpleDevicePassword");
-    m.insert((14, 0x19), "DevicePasswordExpiration");
-    m.insert((14, 0x1A), "DevicePasswordHistory");
-    m.insert((14, 0x1B), "AllowStorageCard");
-    m.insert((14, 0x1C), "AllowCamera");
-    m.insert((14, 0x1D), "RequireDeviceEncryption");
-    m.insert((14, 0x1E), "AllowUnsignedApplications");
-    m.insert((14, 0x1F), "AllowUnsignedInstallationPackages");
-    m.insert((14, 0x20), "MinDevicePasswordComplexCharacters");
-    m.insert((14, 0x21), "AllowWifi");
-    m.insert((14, 0x22), "AllowTextMessaging");
-    m.insert((14, 0x23), "AllowPOPIMAPEmail");
-    m.insert((14, 0x24), "AllowBluetooth");
-    m.insert((14, 0x25), "AllowIrDA");
-    m.insert((14, 0x26), "RequireManualSyncWhenRoaming");
-    m.insert((14, 0x27), "AllowDesktopSync");
-    m.insert((14, 0x28), "MaxCalendarAgeFilter");
-    m.insert((14, 0x29), "AllowHTMLEmail");
-    m.insert((14, 0x2A), "MaxEmailAgeFilter");
-    m.insert((14, 0x2B), "MaxEmailBodyTruncationSize");
-    m.insert((14, 0x2C), "MaxEmailHTMLBodyTruncationSize");
-    m.insert((14, 0x2D), "RequireSignedSMIMEMessages");
-    m.insert((14, 0x2E), "RequireEncryptedSMIMEMessages");
-    m.insert((14, 0x2F), "RequireSignedSMIMEAlgorithm");
-    m.insert((14, 0x30), "RequireEncryptionSMIMEAlgorithm");
-    m.insert((14, 0x31), "AllowSMIMEEncryptionAlgorithmNegotiation");
-    m.insert((14, 0x32), "AllowSMIMESoftCerts");
-    m.insert((14, 0x33), "AllowBrowser");
-    m.insert((14, 0x34), "AllowConsumerEmail");
-    m.insert((14, 0x35), "AllowRemoteDesktop");
-    m.insert((14, 0x36), "AllowInternetSharing");
-    m.insert((14, 0x37), "UnapprovedInROMApplicationList");
-    m.insert((14, 0x38), "ApplicationName");
-    m.insert((14, 0x39), "ApprovedApplicationList");
-    m.insert((14, 0x3A), "Hash");
-
-    m.insert((15, 0x05), "Search");
-    m.insert((15, 0x07), "Store");
-    m.insert((15, 0x08), "Name");
-    m.insert((15, 0x09), "Query");
-    m.insert((15, 0x0A), "Options");
-    m.insert((15, 0x0B), "Range");
-    m.insert((15, 0x0C), "Status");
-    m.insert((15, 0x0D), "Response");
-    m.insert((15, 0x0E), "Result");
-    m.insert((15, 0x0F), "Properties");
-    m.insert((15, 0x10), "Total");
-    m.insert((15, 0x11), "EqualTo");
-    m.insert((15, 0x12), "Value");
-    m.insert((15, 0x13), "And");
-    m.insert((15, 0x14), "Or");
-    m.insert((15, 0x15), "FreeText");
-    m.insert((15, 0x17), "DeepTraversal");
-    m.insert((15, 0x18), "LongId");
-    m.insert((15, 0x19), "RebuildResults");
-    m.insert((15, 0x1A), "LeafName");
-    m.insert((15, 0x1B), "Class");
-    m.insert((15, 0x1C), "CollectionId");
-    m.insert((15, 0x1D), "QueryId");
-    m.insert((15, 0x1E), "MaxResults");
-
-    m.insert((16, 0x05), "GAL:DisplayName");
-    m.insert((16, 0x06), "GAL:Phone");
-    m.insert((16, 0x07), "GAL:Office");
-    m.insert((16, 0x08), "GAL:Title");
-    m.insert((16, 0x09), "GAL:Company");
-    m.insert((16, 0x0A), "GAL:Alias");
-    m.insert((16, 0x0B), "GAL:FirstName");
-    m.insert((16, 0x0C), "GAL:LastName");
-    m.insert((16, 0x0D), "GAL:HomePhone");
-    m.insert((16, 0x0E), "GAL:MobilePhone");
-    m.insert((16, 0x0F), "GAL:EmailAddress");
-    m.insert((16, 0x10), "GAL:Picture");
-    m.insert((16, 0x11), "GAL:Status");
-    m.insert((16, 0x12), "GAL:Data");
-
-    m.insert((17, 0x05), "AirSyncBase:BodyPreference");
-    m.insert((17, 0x06), "AirSyncBase:Type");
-    m.insert((17, 0x07), "AirSyncBase:TruncationSize");
-    m.insert((17, 0x08), "AirSyncBase:AllOrNone");
-    m.insert((17, 0x0A), "AirSyncBase:Body");
-    m.insert((17, 0x0B), "AirSyncBase:Data");
-    m.insert((17, 0x0C), "AirSyncBase:EstimatedDataSize");
-    m.insert((17, 0x0D), "AirSyncBase:Truncated");
-    m.insert((17, 0x0E), "AirSyncBase:Attachments");
-    m.insert((17, 0x0F), "AirSyncBase:Attachment");
-    m.insert((17, 0x10), "AirSyncBase:DisplayName");
-    m.insert((17, 0x11), "AirSyncBase:FileReference");
-    m.insert((17, 0x12), "AirSyncBase:Method");
-    m.insert((17, 0x13), "AirSyncBase:ContentId");
-    m.insert((17, 0x14), "AirSyncBase:ContentLocation");
-    m.insert((17, 0x15), "AirSyncBase:IsInline");
-    m.insert((17, 0x16), "AirSyncBase:NativeBodyType");
-    m.insert((17, 0x17), "AirSyncBase:ContentType");
-    m.insert((17, 0x18), "AirSyncBase:Preview");
-    m.insert((17, 0x19), "AirSyncBase:BodyPartPreference");
-    m.insert((17, 0x1A), "AirSyncBase:BodyPart");
-    m.insert((17, 0x1B), "AirSyncBase:Status");
-    m.insert((17, 0x1C), "AirSyncBase:Add");
-    m.insert((17, 0x1D), "AirSyncBase:Delete");
-    m.insert((17, 0x1E), "AirSyncBase:ClientId");
-    m.insert((17, 0x1F), "AirSyncBase:Content");
-    m.insert((17, 0x20), "AirSyncBase:Location");
-    m.insert((17, 0x21), "AirSyncBase:Annotation");
-    m.insert((17, 0x22), "AirSyncBase:Street");
-    m.insert((17, 0x23), "AirSyncBase:City");
-    m.insert((17, 0x24), "AirSyncBase:State");
-    m.insert((17, 0x25), "AirSyncBase:Country");
-    m.insert((17, 0x26), "AirSyncBase:PostalCode");
-    m.insert((17, 0x27), "AirSyncBase:Latitude");
-    m.insert((17, 0x28), "AirSyncBase:Longitude");
-    m.insert((17, 0x29), "AirSyncBase:Accuracy");
-    m.insert((17, 0x2A), "AirSyncBase:Altitude");
-    m.insert((17, 0x2B), "AirSyncBase:AltitudeAccuracy");
-    m.insert((17, 0x2C), "AirSyncBase:LocationUri");
-    m.insert((17, 0x2D), "AirSyncBase:InstanceId");
-
-    m.insert((18, 0x05), "Settings");
-    m.insert((18, 0x06), "Status");
-    m.insert((18, 0x07), "Get");
-    m.insert((18, 0x08), "Set");
-    m.insert((18, 0x09), "Oof");
-    m.insert((18, 0x0A), "OofState");
-    m.insert((18, 0x0B), "StartTime");
-    m.insert((18, 0x0C), "EndTime");
-    m.insert((18, 0x0D), "OofMessage");
-    m.insert((18, 0x0E), "AppliesToInternal");
-    m.insert((18, 0x0F), "AppliesToExternalKnown");
-    m.insert((18, 0x10), "AppliesToExternalUnknown");
-    m.insert((18, 0x11), "Enabled");
-    m.insert((18, 0x12), "ReplyMessage");
-    m.insert((18, 0x13), "BodyType");
-    m.insert((18, 0x14), "DevicePassword");
-    m.insert((18, 0x15), "Password");
-    m.insert((18, 0x16), "DeviceInformation");
-    m.insert((18, 0x17), "Model");
-    m.insert((18, 0x18), "IMEI");
-    m.insert((18, 0x19), "FriendlyName");
-    m.insert((18, 0x1A), "OS");
-    m.insert((18, 0x1B), "OSLanguage");
-    m.insert((18, 0x1C), "PhoneNumber");
-    m.insert((18, 0x1D), "UserInformation");
-    m.insert((18, 0x1E), "EmailAddresses");
-    m.insert((18, 0x1F), "SMTPAddress");
-    m.insert((18, 0x20), "UserAgent");
-    m.insert((18, 0x21), "EnableOutboundSMS");
-    m.insert((18, 0x22), "MobileOperator");
-    m.insert((18, 0x23), "PrimarySmtpAddress");
-    m.insert((18, 0x24), "Accounts");
-    m.insert((18, 0x25), "Account");
-    m.insert((18, 0x26), "AccountId");
-    m.insert((18, 0x27), "AccountName");
-    m.insert((18, 0x28), "UserDisplayName");
-    m.insert((18, 0x29), "SendDisabled");
-    m.insert((18, 0x2B), "RightsManagementInformation");
-
-    m.insert((19, 0x05), "DocumentLibrary:LinkId");
-    m.insert((19, 0x06), "DocumentLibrary:DisplayName");
-    m.insert((19, 0x07), "DocumentLibrary:IsFolder");
-    m.insert((19, 0x08), "DocumentLibrary:CreationDate");
-    m.insert((19, 0x09), "DocumentLibrary:LastModifiedDate");
-    m.insert((19, 0x0A), "DocumentLibrary:IsHidden");
-    m.insert((19, 0x0B), "DocumentLibrary:ContentLength");
-    m.insert((19, 0x0C), "DocumentLibrary:ContentType");
-
-    m.insert((20, 0x05), "ItemOperations");
-    m.insert((20, 0x06), "Fetch");
-    m.insert((20, 0x07), "Store");
-    m.insert((20, 0x08), "Options");
-    m.insert((20, 0x09), "Range");
-    m.insert((20, 0x0A), "Total");
-    m.insert((20, 0x0B), "Properties");
-    m.insert((20, 0x0C), "Data");
-    m.insert((20, 0x0D), "Status");
-    m.insert((20, 0x0E), "Response");
-    m.insert((20, 0x0F), "Version");
-    m.insert((20, 0x10), "Schema");
-    m.insert((20, 0x11), "Part");
-    m.insert((20, 0x12), "EmptyFolderContents");
-    m.insert((20, 0x13), "DeleteSubFolders");
-    m.insert((20, 0x14), "UserName");
-    m.insert((20, 0x15), "IOPassword");
-    m.insert((20, 0x16), "Move");
-    m.insert((20, 0x17), "DstFldId");
-    m.insert((20, 0x18), "ConversationId");
-    m.insert((20, 0x19), "MoveAlways");
-
-    m.insert((21, 0x05), "SendMail");
-    m.insert((21, 0x06), "SmartForward");
-    m.insert((21, 0x07), "SmartReply");
-    m.insert((21, 0x08), "SaveInSentItems");
-    m.insert((21, 0x09), "ReplaceMime");
-    m.insert((21, 0x0B), "Mime");
-    m.insert((21, 0x0C), "ClientId");
-    m.insert((21, 0x0D), "Status");
-    m.insert((21, 0x0E), "AccountId");
-    m.insert((21, 0x0F), "Forwardees");
-    m.insert((21, 0x10), "Forwardee");
-    m.insert((21, 0x11), "ForwardeeName");
-    m.insert((21, 0x12), "ForwardeeEmail");
-
-    m.insert((22, 0x05), "Email2:UmCallerId");
-    m.insert((22, 0x06), "Email2:UmUserNotes");
-    m.insert((22, 0x07), "Email2:UmAttDuration");
-    m.insert((22, 0x08), "Email2:UmAttOrder");
-    m.insert((22, 0x09), "Email2:ConversationId");
-    m.insert((22, 0x0A), "Email2:ConversationIndex");
-    m.insert((22, 0x0B), "Email2:LastVerbExecuted");
-    m.insert((22, 0x0C), "Email2:LastVerbExecutionTime");
-    m.insert((22, 0x0D), "Email2:ReceivedAsBcc");
-    m.insert((22, 0x0E), "Email2:Sender");
-    m.insert((22, 0x0F), "Email2:CalendarType");
-    m.insert((22, 0x10), "Email2:IsLeapMonth");
-    m.insert((22, 0x11), "Email2:AccountId");
-    m.insert((22, 0x12), "Email2:FirstDayOfWeek");
-    m.insert((22, 0x13), "Email2:MeetingMessageType");
-
-    m.insert((23, 0x05), "Notes:Subject");
-    m.insert((23, 0x06), "Notes:MessageClass");
-    m.insert((23, 0x07), "Notes:LastModifiedDate");
-    m.insert((23, 0x08), "Notes:Categories");
-    m.insert((23, 0x09), "Notes:Category");
-    m.insert((23, 0x0B), "Notes:Body");
-
-    m.insert((24, 0x05), "RightsManagement:RightsManagementSupport");
-    m.insert((24, 0x06), "RightsManagement:RightsManagementTemplates");
-    m.insert((24, 0x07), "RightsManagement:RightsManagementTemplate");
-    m.insert((24, 0x08), "RightsManagement:RightsManagementLicense");
-    m.insert((24, 0x09), "RightsManagement:EditAllowed");
-    m.insert((24, 0x0A), "RightsManagement:ReplyAllowed");
-    m.insert((24, 0x0B), "RightsManagement:ReplyAllAllowed");
-    m.insert((24, 0x0C), "RightsManagement:ForwardAllowed");
-    m.insert((24, 0x0D), "RightsManagement:ModifyRecipientsAllowed");
-    m.insert((24, 0x0E), "RightsManagement:ExtractAllowed");
-    m.insert((24, 0x0F), "RightsManagement:PrintAllowed");
-    m.insert((24, 0x10), "RightsManagement:ExportAllowed");
-    m.insert((24, 0x11), "RightsManagement:ProgrammaticAccessAllowed");
-    m.insert((24, 0x12), "RightsManagement:RMOwner");
-    m.insert((24, 0x13), "RightsManagement:ContentExpiryDate");
-    m.insert((24, 0x14), "RightsManagement:ContentExpiryDateString");
-    m.insert((24, 0x15), "RightsManagement:ContentExpiryInterval");
-    m.insert((24, 0x16), "RightsManagement:ContentExpiryIntervalType");
-    m.insert((24, 0x17), "RightsManagement:TemplateID");
-    m.insert((24, 0x18), "RightsManagement:TemplateName");
-    m.insert((24, 0x19), "RightsManagement:TemplateDescription");
-    m.insert((24, 0x1A), "RightsManagement:ContentOwner");
-    m.insert((24, 0x1B), "RightsManagement:RemoveRightsManagementDistribution");
-
-    m
 }
 
 pub struct Wbxml;
@@ -759,7 +1206,7 @@ impl Wbxml {
                     if token >= 0x05 {
                         let has_content = (token & 0x40) != 0;
                         let tag_id = token & 0x3F;
-                        if let Some(name) = TAG_TO_NAME.get(&(current_code_page, tag_id)) {
+                        if let Some(name) = TAG_TO_NAME.get(&[current_code_page, tag_id]) {
                             output.push_str(&format!("<{name}>"));
                             if has_content {
                                 xml_stack.push(name.to_string());


### PR DESCRIPTION
…e-normalization

- Replace custom xml_escape/xml_escape_text with quick_xml::escape::escape/partial_escape (returns Cow<str>)
- Remove EscapedXml/EscapedXmlText display wrappers
- Replace LazyLock<HashMap<(u8,u8), &str>> with compile-time phf::Map<[u8;2], &str> for WBXML lookup (522 entries, zero startup cost)
- Add icalendar 0.17.10 with parser feature; replace custom unfold_ical_content with icalendar::parser::unfold()
- Replace 2 inline unfold copies in calendar.rs with ical_parser::unfold_ical_content()
- Add unicode-normalization 0.1.25 (preferred over icu_normalizer: 0 vs 50+ crate tree)
- Add const-hex 1.18.1, bitflags 2.9.0 for future standardization
- Remove dead calcard 0.3.2 dependency
- Add AGENTS.md contributor guide with dependency decisions and code patterns
- All 68 tests passing