### PR TITLE
Refactor PermissionRights and PermissionLevel

### DIFF
--- a/src/permission/types.rs
+++ b/src/permission/types.rs
@@ -1,11 +1,11 @@
-// src/permission/types.rs
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    #[serde(transparent)]
     pub struct PermissionRights: u32 {
         const READ_ANY          = 0x00000001;
         const CREATE            = 0x00000002;
@@ -22,60 +22,13 @@ bitflags! {
     }
 }
 
-// Serde: serialize as u32, deserialize from u32 — preserves wire format compatibility
-impl Serialize for PermissionRights {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_u32(self.bits())
-    }
-}
-
-impl<'de> Deserialize<'de> for PermissionRights {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let bits = u32::deserialize(deserializer)?;
-        Ok(Self::from_bits_retain(bits))
+impl Default for PermissionRights {
+    fn default() -> Self {
+        Self::empty()
     }
 }
 
 impl PermissionRights {
-    // Named single-flag constructors
-    pub fn read_any() -> Self {
-        Self::READ_ANY
-    }
-    pub fn create() -> Self {
-        Self::CREATE
-    }
-    pub fn edit_owned() -> Self {
-        Self::EDIT_OWNED
-    }
-    pub fn delete_owned() -> Self {
-        Self::DELETE_OWNED
-    }
-    pub fn edit_any() -> Self {
-        Self::EDIT_ANY | Self::EDIT_OWNED
-    }
-    pub fn delete_any() -> Self {
-        Self::DELETE_ANY | Self::DELETE_OWNED
-    }
-    pub fn folder_owner() -> Self {
-        Self::FOLDER_OWNER | Self::FOLDER_VISIBLE
-    }
-    pub fn folder_contact() -> Self {
-        Self::FOLDER_CONTACT
-    }
-    pub fn folder_visible() -> Self {
-        Self::FOLDER_VISIBLE
-    }
-    pub fn freebusy_simple() -> Self {
-        Self::FREEBUSY_SIMPLE
-    }
-    pub fn freebusy_detailed() -> Self {
-        Self::FREEBUSY_DETAILED | Self::FREEBUSY_SIMPLE
-    }
-
-    // Named composite constructors (permission levels)
-    pub fn none() -> Self {
-        Self::empty()
-    }
     pub fn reviewer() -> Self {
         Self::READ_ANY | Self::FOLDER_VISIBLE
     }
@@ -89,125 +42,19 @@ impl PermissionRights {
         Self::READ_ANY | Self::CREATE | Self::DELETE_OWNED | Self::FOLDER_VISIBLE
     }
     pub fn editor() -> Self {
-        Self::READ_ANY | Self::CREATE | Self::edit_any() | Self::delete_any() | Self::FOLDER_VISIBLE
+        Self::READ_ANY | Self::CREATE | Self::EDIT_ANY | Self::EDIT_OWNED | Self::DELETE_ANY | Self::DELETE_OWNED | Self::FOLDER_VISIBLE
     }
     pub fn publishing_author() -> Self {
-        Self::READ_ANY
-            | Self::CREATE
-            | Self::EDIT_OWNED
-            | Self::DELETE_OWNED
-            | Self::CREATE_SUBFOLDER
-            | Self::FOLDER_VISIBLE
+        Self::READ_ANY | Self::CREATE | Self::EDIT_OWNED | Self::DELETE_OWNED | Self::CREATE_SUBFOLDER | Self::FOLDER_VISIBLE
     }
     pub fn publishing_editor() -> Self {
-        Self::READ_ANY
-            | Self::CREATE
-            | Self::edit_any()
-            | Self::delete_any()
-            | Self::CREATE_SUBFOLDER
-            | Self::FOLDER_VISIBLE
+        Self::READ_ANY | Self::CREATE | Self::EDIT_ANY | Self::EDIT_OWNED | Self::DELETE_ANY | Self::DELETE_OWNED | Self::CREATE_SUBFOLDER | Self::FOLDER_VISIBLE
     }
     pub fn owner() -> Self {
-        Self::READ_ANY
-            | Self::CREATE
-            | Self::edit_any()
-            | Self::delete_any()
-            | Self::CREATE_SUBFOLDER
-            | Self::FOLDER_OWNER
-            | Self::FOLDER_CONTACT
-            | Self::FOLDER_VISIBLE
+        Self::READ_ANY | Self::CREATE | Self::EDIT_ANY | Self::EDIT_OWNED | Self::DELETE_ANY | Self::DELETE_OWNED | Self::CREATE_SUBFOLDER | Self::FOLDER_OWNER | Self::FOLDER_CONTACT | Self::FOLDER_VISIBLE
     }
     pub fn freebusy() -> Self {
         Self::FREEBUSY_SIMPLE | Self::FREEBUSY_DETAILED | Self::FOLDER_VISIBLE
-    }
-
-    // Convenience predicates (preserving the existing API names)
-    pub fn can_read_any(&self) -> bool {
-        self.contains(Self::READ_ANY)
-    }
-    pub fn can_create(&self) -> bool {
-        self.contains(Self::CREATE)
-    }
-    pub fn can_edit_owned(&self) -> bool {
-        self.contains(Self::EDIT_OWNED)
-    }
-    pub fn can_delete_owned(&self) -> bool {
-        self.contains(Self::DELETE_OWNED)
-    }
-    pub fn can_edit_any(&self) -> bool {
-        self.contains(Self::EDIT_ANY)
-    }
-    pub fn can_delete_any(&self) -> bool {
-        self.contains(Self::DELETE_ANY)
-    }
-    pub fn can_create_subfolder(&self) -> bool {
-        self.contains(Self::CREATE_SUBFOLDER)
-    }
-    pub fn is_folder_owner(&self) -> bool {
-        self.contains(Self::FOLDER_OWNER)
-    }
-    pub fn is_folder_contact(&self) -> bool {
-        self.contains(Self::FOLDER_CONTACT)
-    }
-    pub fn is_folder_visible(&self) -> bool {
-        self.contains(Self::FOLDER_VISIBLE)
-    }
-    pub fn can_freebusy_simple(&self) -> bool {
-        self.contains(Self::FREEBUSY_SIMPLE)
-    }
-    pub fn can_freebusy_detailed(&self) -> bool {
-        self.contains(Self::FREEBUSY_DETAILED)
-    }
-}
-
-impl fmt::Display for PermissionRights {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_empty() {
-            return write!(f, "None");
-        }
-        let mut parts: Vec<String> = Vec::new();
-        if self.can_read_any() {
-            parts.push("ReadAny".to_string());
-        }
-        if self.can_create() {
-            parts.push("Create".to_string());
-        }
-        if self.can_edit_owned() {
-            parts.push("EditOwned".to_string());
-        }
-        if self.can_delete_owned() {
-            parts.push("DeleteOwned".to_string());
-        }
-        if self.can_edit_any() {
-            parts.push("EditAny".to_string());
-        }
-        if self.can_delete_any() {
-            parts.push("DeleteAny".to_string());
-        }
-        if self.can_create_subfolder() {
-            parts.push("CreateSubfolder".to_string());
-        }
-        if self.is_folder_owner() {
-            parts.push("FolderOwner".to_string());
-        }
-        if self.is_folder_contact() {
-            parts.push("FolderContact".to_string());
-        }
-        if self.is_folder_visible() {
-            parts.push("FolderVisible".to_string());
-        }
-        if self.can_freebusy_simple() {
-            parts.push("FreeBusySimple".to_string());
-        }
-        if self.can_freebusy_detailed() {
-            parts.push("FreeBusyDetailed".to_string());
-        }
-        let known_mask = PermissionRights::all().bits();
-        let unknown_bits = self.bits() & !known_mask;
-        if unknown_bits != 0 {
-            parts.push(format!("Unknown(0x{:08X})", unknown_bits));
-        }
-        write!(f, "{}", parts.join("|"))
     }
 }
 
@@ -224,6 +71,7 @@ impl From<PermissionRights> for u32 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[repr(u8)]
 pub enum PermissionLevel {
     #[default]
     None = 0,
@@ -239,9 +87,9 @@ pub enum PermissionLevel {
 }
 
 impl PermissionLevel {
-    pub fn to_rights(&self) -> PermissionRights {
+    pub fn to_rights(self) -> PermissionRights {
         match self {
-            Self::None => PermissionRights::none(),
+            Self::None => PermissionRights::empty(),
             Self::FreeBusy => PermissionRights::freebusy(),
             Self::Reviewer => PermissionRights::reviewer(),
             Self::Contributor => PermissionRights::contributor(),
@@ -254,41 +102,22 @@ impl PermissionLevel {
         }
     }
 
-    pub fn from_rights(rights: &PermissionRights) -> Self {
-        if rights.is_folder_owner() {
-            return Self::Owner;
-        }
-        if rights.contains(PermissionRights::publishing_editor()) {
-            return Self::PublishingEditor;
-        }
-        if rights.contains(PermissionRights::editor()) {
-            return Self::Editor;
-        }
-        if rights.contains(PermissionRights::publishing_author()) {
-            return Self::PublishingAuthor;
-        }
-        if rights.contains(PermissionRights::author()) {
-            return Self::Author;
-        }
-        if rights.contains(PermissionRights::non_editing_author()) {
-            return Self::NonEditingAuthor;
-        }
-        if rights.contains(PermissionRights::contributor()) {
-            return Self::Contributor;
-        }
-        if rights.contains(PermissionRights::reviewer()) {
-            return Self::Reviewer;
-        }
-        if rights.can_freebusy_simple() {
-            return Self::FreeBusy;
-        }
+    pub fn from_rights(rights: PermissionRights) -> Self {
+        if rights.contains(PermissionRights::FOLDER_OWNER) { return Self::Owner; }
+        if rights.contains(PermissionRights::publishing_editor()) { return Self::PublishingEditor; }
+        if rights.contains(PermissionRights::editor()) { return Self::Editor; }
+        if rights.contains(PermissionRights::publishing_author()) { return Self::PublishingAuthor; }
+        if rights.contains(PermissionRights::author()) { return Self::Author; }
+        if rights.contains(PermissionRights::non_editing_author()) { return Self::NonEditingAuthor; }
+        if rights.contains(PermissionRights::contributor()) { return Self::Contributor; }
+        if rights.contains(PermissionRights::reviewer()) { return Self::Reviewer; }
+        if rights.contains(PermissionRights::FREEBUSY_SIMPLE) { return Self::FreeBusy; }
         Self::None
     }
 
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::None => "None",
-            // EWS uses FreeBusyTimeOnly for this permission level
             Self::FreeBusy => "FreeBusyTimeOnly",
             Self::Reviewer => "Reviewer",
             Self::Contributor => "Contributor",
@@ -304,7 +133,7 @@ impl PermissionLevel {
 
 impl fmt::Display for PermissionLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 
@@ -331,7 +160,6 @@ impl FromStr for PermissionLevel {
 impl From<u8> for PermissionLevel {
     fn from(value: u8) -> Self {
         match value {
-            0 => Self::None,
             1 => Self::FreeBusy,
             2 => Self::Reviewer,
             3 => Self::Contributor,
@@ -367,64 +195,40 @@ pub struct CalendarPermission {
 }
 
 impl CalendarPermission {
-    pub fn new(
+    fn initialize(
         folder_id: String,
         owner: String,
         user_email: String,
+        user_name: Option<String>,
         rights: PermissionRights,
+        is_default: bool,
+        is_anonymous: bool,
     ) -> Self {
         let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
         Self {
-            id,
+            id: uuid::Uuid::new_v4().to_string(),
             folder_id,
             owner,
             user_email,
-            user_name: None,
+            user_name,
             rights: rights.bits(),
-            is_default: false,
-            is_anonymous: false,
+            is_default,
+            is_anonymous,
             created_at: now,
             updated_at: now,
         }
+    }
+
+    pub fn new(folder_id: String, owner: String, user_email: String, rights: PermissionRights) -> Self {
+        Self::initialize(folder_id, owner, user_email, None, rights, false, false)
     }
 
     pub fn default_permission(folder_id: String, owner: String, rights: PermissionRights) -> Self {
-        let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
-        Self {
-            id,
-            folder_id,
-            owner,
-            user_email: "default".to_string(),
-            user_name: Some("Default".to_string()),
-            rights: rights.bits(),
-            is_default: true,
-            is_anonymous: false,
-            created_at: now,
-            updated_at: now,
-        }
+        Self::initialize(folder_id, owner, "default".to_string(), Some("Default".to_string()), rights, true, false)
     }
 
-    pub fn anonymous_permission(
-        folder_id: String,
-        owner: String,
-        rights: PermissionRights,
-    ) -> Self {
-        let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
-        Self {
-            id,
-            folder_id,
-            owner,
-            user_email: "anonymous".to_string(),
-            user_name: Some("Anonymous".to_string()),
-            rights: rights.bits(),
-            is_default: false,
-            is_anonymous: true,
-            created_at: now,
-            updated_at: now,
-        }
+    pub fn anonymous_permission(folder_id: String, owner: String, rights: PermissionRights) -> Self {
+        Self::initialize(folder_id, owner, "anonymous".to_string(), Some("Anonymous".to_string()), rights, false, true)
     }
 
     pub fn rights(&self) -> PermissionRights {
@@ -437,7 +241,7 @@ impl CalendarPermission {
     }
 
     pub fn permission_level(&self) -> PermissionLevel {
-        PermissionLevel::from_rights(&self.rights())
+        PermissionLevel::from_rights(self.rights())
     }
 }
 
@@ -448,14 +252,6 @@ pub struct DelegateInfo {
     pub delegate_email: String,
     pub delegate_name: Option<String>,
     pub calendar_permission: u8,
-    pub inbox_permission: u8,
-    pub tasks_permission: u8,
-    pub contacts_permission: u8,
-    pub notes_permission: u8,
-    pub journal_permission: u8,
-    pub receive_copies: bool,
-    pub receive_infos: bool,
-    pub view_private: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -463,21 +259,12 @@ pub struct DelegateInfo {
 impl DelegateInfo {
     pub fn new(delegator: String, delegate_email: String, delegate_name: Option<String>) -> Self {
         let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
         Self {
-            id,
+            id: uuid::Uuid::new_v4().to_string(),
             delegator,
             delegate_email,
             delegate_name,
             calendar_permission: PermissionLevel::Reviewer as u8,
-            inbox_permission: PermissionLevel::None as u8,
-            tasks_permission: PermissionLevel::None as u8,
-            contacts_permission: PermissionLevel::None as u8,
-            notes_permission: PermissionLevel::None as u8,
-            journal_permission: PermissionLevel::None as u8,
-            receive_copies: false,
-            receive_infos: false,
-            view_private: false,
             created_at: now,
             updated_at: now,
         }
@@ -497,90 +284,6 @@ impl DelegateInfo {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub enum DelegatePermission {
-    #[default]
-    None = 0,
-    Author = 1,
-    Editor = 2,
-}
-
-impl DelegatePermission {
-    pub fn to_rights(&self) -> PermissionRights {
-        match self {
-            Self::None => PermissionRights::none(),
-            Self::Author => PermissionRights::author(),
-            Self::Editor => PermissionRights::editor(),
-        }
-    }
-
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::None => "None",
-            Self::Author => "Author",
-            Self::Editor => "Editor",
-        }
-    }
-}
-
-impl fmt::Display for DelegatePermission {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl FromStr for DelegatePermission {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "none" => Ok(Self::None),
-            "author" => Ok(Self::Author),
-            "editor" => Ok(Self::Editor),
-            _ => Err(()),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PermissionAuditEntry {
-    pub id: String,
-    pub folder_id: String,
-    pub owner: String,
-    pub actor_email: String,
-    pub target_email: String,
-    pub operation: String,
-    pub old_rights: Option<u32>,
-    pub new_rights: Option<u32>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-}
-
-impl PermissionAuditEntry {
-    pub fn new(
-        folder_id: String,
-        owner: String,
-        actor_email: String,
-        target_email: String,
-        operation: String,
-        old_rights: Option<u32>,
-        new_rights: Option<u32>,
-    ) -> Self {
-        let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
-        Self {
-            id,
-            folder_id,
-            owner,
-            actor_email,
-            target_email,
-            operation,
-            old_rights,
-            new_rights,
-            created_at: now,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -588,21 +291,21 @@ mod tests {
     #[test]
     fn test_permission_rights_flags() {
         let rights = PermissionRights::owner();
-        assert!(rights.can_read_any());
-        assert!(rights.can_create());
-        assert!(rights.can_edit_any());
-        assert!(rights.can_delete_any());
-        assert!(rights.is_folder_owner());
+        assert!(rights.contains(PermissionRights::READ_ANY));
+        assert!(rights.contains(PermissionRights::CREATE));
+        assert!(rights.contains(PermissionRights::EDIT_ANY));
+        assert!(rights.contains(PermissionRights::DELETE_ANY));
+        assert!(rights.contains(PermissionRights::FOLDER_OWNER));
     }
 
     #[test]
     fn test_permission_level_conversion() {
         let level = PermissionLevel::Editor;
         let rights = level.to_rights();
-        assert!(rights.can_edit_any());
-        assert!(rights.can_delete_any());
+        assert!(rights.contains(PermissionRights::EDIT_ANY));
+        assert!(rights.contains(PermissionRights::DELETE_ANY));
 
-        let converted = PermissionLevel::from_rights(&rights);
+        let converted = PermissionLevel::from_rights(rights);
         assert_eq!(level, converted);
     }
 
@@ -621,9 +324,6 @@ mod tests {
             "delegate@example.com".to_string(),
             Some("Delegate Name".to_string()),
         );
-        assert_eq!(
-            delegate.calendar_permission_level(),
-            PermissionLevel::Reviewer
-        );
+        assert_eq!(delegate.calendar_permission_level(), PermissionLevel::Reviewer);
     }
 }


### PR DESCRIPTION
Refactor PermissionRights to derive Serialize and Deserialize traits. Update PermissionLevel methods and simplify permission handling.