### PR TITLE
Refactor windows_name_to_iana return type and logic

### DIFF
--- a/src/timezone.rs
+++ b/src/timezone.rs
@@ -67,17 +67,20 @@ fn find_windows_timezone(name: &str) -> Option<WindowsTimezone> {
         .max_by_key(|variant| variant.name().len())
 }
 
-fn windows_name_to_iana(name: &str) -> Option<&'static str> {
-      let n = name.trim();
-      if n.is_empty() {
-          return None;
-      }
-      if let Some(tz) = parse_utc_offset_name(n) {
-          // parse_utc_offset_name must also return &'static str
-          return Some(tz);
-      }
-      find_windows_timezone(n).map(|tz| tz.tzdb_id())
-  }
+fn windows_name_to_iana(name: &str) -> Option<String> {
+    let n = name.trim();
+    if n.is_empty() {
+        return None;
+    }
+
+    // First try UTC offset names like "(UTC+02:00) Custom" for better compatibility
+    if let Some(tz) = parse_utc_offset_name(n) {
+        return Some(tz);
+    }
+
+    // Then fall back to Windows timezone name resolution
+    find_windows_timezone(n).map(|tz| tz.tzdb_id().to_string())
+}
     let n = name.trim();
     if n.is_empty() {
         return None;

--- a/src/timezone.rs
+++ b/src/timezone.rs
@@ -81,19 +81,6 @@ fn windows_name_to_iana(name: &str) -> Option<String> {
     // Then fall back to Windows timezone name resolution
     find_windows_timezone(n).map(|tz| tz.tzdb_id().to_string())
 }
-    let n = name.trim();
-    if n.is_empty() {
-        return None;
-    }
-
-    // First try UTC offset names like "(UTC+02:00) Custom" for better compatibility
-    if let Some(tz) = parse_utc_offset_name(n) {
-        return Some(tz);
-    }
-
-    // Then fall back to Windows timezone name resolution
-    find_windows_timezone(n).map(|tz| tz.tzdb_id().to_string())
-}
 
 pub fn eas_timezone_blob_to_iana(b64: &str) -> Option<String> {
     let bytes = BASE64.decode(b64.trim()).ok()?;


### PR DESCRIPTION
Refactor windows_name_to_iana function to return Option<String> instead of Option<&'static str> and improve code structure.