### PR TITLE
Refactor timezone name resolution logic

### DIFF
--- a/src/timezone.rs
+++ b/src/timezone.rs
@@ -81,19 +81,6 @@ fn windows_name_to_iana(name: &str) -> Option<String> {
     // Then fall back to Windows timezone name resolution
     find_windows_timezone(n).map(|tz| tz.tzdb_id().to_string())
 }
-    let n = name.trim();
-    if n.is_empty() {
-        return None;
-    }
-
-    // First try UTC offset names like "(UTC+02:00) Custom" for better compatibility
-    if let Some(tz) = parse_utc_offset_name(n) {
-        return Some(tz);
-    }
-
-    // Then fall back to Windows timezone name resolution
-    find_windows_timezone(n).map(|tz| tz.tzdb_id().to_string())
-}
 
 pub fn eas_timezone_blob_to_iana(b64: &str) -> Option<String> {
     let bytes = BASE64.decode(b64.trim()).ok()?;


### PR DESCRIPTION
Removed redundant checks for empty timezone name and streamlined the timezone resolution process.