### PR TITLE
Refactor: replace hand-rolled iCal/enum code with icalendar, strum, i…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Exchange Gateway - Agent Memory
+
+## Project Overview
+Rust exchange gateway implementing EAS (Exchange ActiveSync), EWS (Exchange Web Services), CalDAV, and IMAP protocols. Synchronizes calendar, contacts, and email between Exchange/Outlook and downstream clients.
+
+## Build & Test
+- `cargo build` - builds the library
+- `cargo build --release` - release build (~3 min)
+- `cargo test` - runs all tests (unit + snapshot)
+- `cargo test --lib` - library unit tests only
+
+## Key Dependencies & API Notes
+
+### icalendar ^0.17.10
+- **Imports**: `use icalendar::{Calendar, Component, Event, EventLike, Property, Class, EventStatus, Parameter, Alarm, Related, Trigger, Attendee, Role, PartStat, CUType, CalendarDateTime, DatePerhapsTime};`
+- `EventLike` trait is required for `.starts()`, `.ends()`, `.all_day()`, `.location()` on `Event`
+- `DatePerhapsTime::From<(NaiveDateTime, Tz)>` is the way to pass timezone-aware datetimes (NOT `DateTime<Tz>` directly)
+- `Property::add_parameter()` returns `&mut Self` — must call `.done()` at end of builder chain to get owned `Property`
+- `Alarm::display(description, trigger)` creates VALARM components; trigger can be `chrono::Duration` or `(Duration, Related)`
+- `event.alarm(alarm)` adds VALARM as proper sub-component (not raw property)
+- `Event::status(EventStatus::Tentative|Confirmed|Cancelled)` sets STATUS property
+- No `Transp` enum exported — use `event.add_property("TRANSP", "OPAQUE"/"TRANSPARENT")` directly
+- `recurrence()` method requires `recurrence` feature flag — use `add_property("RRULE", ...)` as fallback
+- `icalendar::parser::unfold(input)` handles RFC 5545 line unfolding
+
+### iso8601-duration ^0.2.0
+- **Import**: `use iso8601_duration::Duration as IsoDuration;`
+- **Parse**: `IsoDuration::parse("PT1H30M")` or `"PT1H30M".parse::<IsoDuration>()`
+- No `parser` module — use `Duration::parse()` or `FromStr` impl
+- Fields are `f32`: `year`, `month`, `day`, `hour`, `minute`, `second` (no `week`, no `millisecond`)
+- `num_minutes()`, `num_hours()`, `num_seconds()` return `Option<f32>` — `None` if year/month nonzero
+- `to_std()` converts to `std::time::Duration` (returns `None` if year/month nonzero)
+
+### strum ~0.27.2
+- **Derives**: `strum::Display`, `strum::FromRepr`
+- `#[strum(serialize = "DISPLAY_VALUE")]` for custom Display output
+- `FromRepr::from_repr(usize)` — always takes `usize`, not `u8` (cast with `as usize`)
+- Multiple variants can share same serialize value (e.g., `NotResponded` → "NEEDS-ACTION")
+
+## Architecture
+- `src/lib.rs` — crate root, re-exports modules
+- `src/main.rs` — CLI entrypoint (axum server)
+- `src/config.rs` — configuration loading (toml-based)
+- `src/models.rs` — core data models (CalendarItem, etc.)
+- `src/error.rs` — error types
+- `src/util.rs` — shared utilities (normalize_email, escape_ical_text, etc.)
+- `src/traits.rs` — shared traits
+- `src/calendar.rs` — Calendar ICS parsing and rendering (uses icalendar crate for rendering)
+- `src/ical_parser.rs` — iCal content parsing helpers (uses icalendar::parser::unfold, iso8601-duration)
+- `src/meeting/` — Meeting/iPIM modules (attendee, message, scheduling, types)
+- `src/eas.rs` — EAS protocol implementation
+- `src/ews.rs` — EWS protocol implementation
+- `src/permission/` — Permission types (uses strum derives)
+
+## Code Patterns
+- Use `icalendar` crate builders for all ICS generation (Calendar → Event → .done() → .push() → .done())
+- Use `iso8601_duration::Duration::parse()` for duration parsing, then convert to minutes via `num_minutes()` or manual f32 math
+- Use `strum::Display` derive instead of hand-written `fmt::Display` impls for enums
+- Use `strum::FromRepr` derive instead of hand-written `From<u8>` where appropriate (remember `usize` cast)
+- The `chrono::Tz` type (from `chrono-tz`) is used for timezone handling — pass by value, not by deref

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -813,12 +813,13 @@ dependencies = [
  "hyper-util",
  "icalendar",
  "insta",
+ "iso8601-duration",
  "itoa",
  "lru",
  "memchr",
  "mime",
  "moka",
- "nom",
+ "nom 8.0.0",
  "opentelemetry 0.29.1",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.29.0",
@@ -1328,8 +1329,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "264fe856964b7a84076dec2d8ea29fce7c9b422968c9a2f404d4aa3771ae2179"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "iso8601",
- "nom",
+ "nom 8.0.0",
  "nom-language",
  "uuid",
 ]
@@ -1499,7 +1501,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom",
+ "nom 8.0.0",
+]
+
+[[package]]
+name = "iso8601-duration"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26adff60a5d3ca10dc271ad37a34ff376595d2a1e5f21d02564929ca888c511"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1680,6 +1691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1736,16 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -1732,7 +1759,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -1741,7 +1768,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2544,7 +2571,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2601,7 +2628,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2882,7 +2909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2989,10 +3016,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3699,7 +3726,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ memchr = "^2.8.0"
 itoa = "^1.0.18"
 ryu = "^1.0.23"
 windows-timezones = { version = "^0.5.1", features = ["strum", "chrono-tz"] }
-strum = "~0.27.2"
+strum = { version = "~0.27.2", features = ["derive"] }
 dashmap = "^6.1.0"
 smallvec = { version = "^1.15.1", features = ["serde", "write"] }
 http = "^1.4.0"
@@ -72,8 +72,9 @@ const-hex = "^1.18.1"
 bitflags = "^2.11.1"
 unicode-normalization = "^0.1.25"
 phf = { version = "^0.13.1", features = ["macros"] }
-icalendar = { version = "^0.17.10", features = ["parser"] }
+icalendar = { version = "^0.17.10", features = ["parser", "chrono-tz"] }
 email_address = "^0.2.9"
+iso8601-duration = "^0.2.0"
 
 [dev-dependencies]
 proptest = "^1.11.0"

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -1,6 +1,6 @@
 // src/calendar.rs
 use crate::ical_parser;
-use crate::util::{escape_ical_text, nfc};
+use crate::util::nfc;
 use anyhow::{Result, anyhow};
 use chrono::{NaiveDate, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
@@ -486,84 +486,8 @@ fn parse_datetime_with_tzid(val: &str, tzid: Option<&str>) -> Option<chrono::Dat
     parse_datetime(val)
 }
 
-fn format_ical_datetime_with_timezone(
-    dt: &chrono::DateTime<Utc>,
-    all_day: bool,
-    timezone: Option<&str>,
-) -> (Option<String>, String) {
-    if all_day {
-        return (None, dt.format("%Y%m%d").to_string());
-    }
-    if let Some(tzid) = timezone
-        && let Ok(tz) = tzid.parse::<Tz>()
-    {
-        return (
-            Some(tzid.to_string()),
-            dt.with_timezone(&tz).format("%Y%m%dT%H%M%S").to_string(),
-        );
-    }
-    (None, dt.format("%Y%m%dT%H%M%SZ").to_string())
-}
-
 fn parse_duration_minutes(trigger: &str) -> Option<i32> {
     ical_parser::parse_ical_duration_minutes(trigger).ok()
-}
-
-fn fold_ics_line(line: &str) -> String {
-    const MAX_LINE_LEN: usize = 75;
-    if line.len() <= MAX_LINE_LEN {
-        return line.to_string();
-    }
-    let mut result = String::with_capacity(line.len() + (line.len() / MAX_LINE_LEN) * 3);
-    let mut remaining = line;
-    let mut first = true;
-    while !remaining.is_empty() {
-        let max_take = if first {
-            MAX_LINE_LEN
-        } else {
-            MAX_LINE_LEN - 1
-        };
-        if remaining.len() <= max_take {
-            if !first {
-                result.push_str("\r\n ");
-            }
-            result.push_str(remaining);
-            break;
-        }
-        let mut split_pos = max_take;
-        while split_pos > 0 && !remaining.is_char_boundary(split_pos) {
-            split_pos -= 1;
-        }
-        if split_pos == 0 {
-            split_pos = max_take.min(remaining.len());
-            while split_pos < remaining.len() && !remaining.is_char_boundary(split_pos) {
-                split_pos += 1;
-            }
-        }
-        if !first {
-            result.push_str("\r\n ");
-        }
-        result.push_str(&remaining[..split_pos]);
-        remaining = &remaining[split_pos..];
-        first = false;
-    }
-    result
-}
-
-fn render_valarm(minutes_before_start: i32) -> Vec<String> {
-    let abs = minutes_before_start.abs();
-    let trigger = if abs % 60 == 0 {
-        format!("-PT{}H", abs / 60)
-    } else {
-        format!("-PT{}M", abs)
-    };
-    vec![
-        "BEGIN:VALARM".to_string(),
-        "ACTION:DISPLAY".to_string(),
-        "DESCRIPTION:Reminder".to_string(),
-        format!("TRIGGER:{trigger}"),
-        "END:VALARM".to_string(),
-    ]
 }
 
 fn parse_event_lines(lines: &[String]) -> CalendarEventFields {
@@ -825,184 +749,219 @@ pub fn parse_ics_event(ics: &str) -> Option<CalendarItem> {
 
 #[must_use]
 pub fn render_ics(item: &CalendarItem) -> String {
-    let dtstamp = item
-        .dtstamp
-        .unwrap_or_else(Utc::now)
-        .format("%Y%m%dT%H%M%SZ")
-        .to_string();
+    use icalendar::{Calendar, Class, Component, Event, EventLike, Property};
+
+    let dtstamp = item.dtstamp.unwrap_or_else(Utc::now);
     let uid = if item.uid.is_empty() {
         Uuid::new_v4().to_string()
     } else {
         item.uid.clone()
     };
 
-    let mut lines = vec![
-        "BEGIN:VCALENDAR".to_string(),
-        "VERSION:2.0".to_string(),
-        "PRODID:-//exchange_gateway//EN".to_string(),
-    ];
+    let mut calendar = Calendar::new();
+    calendar.append_property(Property::new("PRODID", "-//exchange_gateway//EN"));
+
+    // Embed timezone blob if present
     if let Some(blob) = &item.timezone_blob {
         for line in blob.lines() {
             let trimmed = line.trim_end();
             if !trimmed.is_empty() {
-                lines.push(trimmed.to_string());
+                if let Some(colon_pos) = trimmed.find(':') {
+                    calendar.append_property(
+                        Property::new(&trimmed[..colon_pos], &trimmed[colon_pos + 1..]),
+                    );
+                }
             }
         }
     }
-    let (dtstart_tzid, dtstart_value) =
-        format_ical_datetime_with_timezone(&item.start, item.all_day, item.timezone.as_deref());
-    let (dtend_tzid, dtend_value) =
-        format_ical_datetime_with_timezone(&item.end, item.all_day, item.timezone.as_deref());
-    let dtstart_line = if let Some(tzid) = dtstart_tzid {
-        format!("DTSTART;TZID={}:{}", escape_ical_text(&tzid), dtstart_value)
+
+    // Build the main event using the icalendar crate (handles escaping + folding)
+    let mut event = Event::new();
+    event.uid(&uid);
+    event.timestamp(dtstamp);
+    event.summary(&item.subject);
+
+    if item.all_day {
+        event.all_day(item.start.naive_utc().date());
+    } else if let Some(tzid) = &item.timezone
+        && let Ok(tz) = tzid.parse::<Tz>()
+    {
+        event.starts((item.start.naive_utc(), tz));
+        event.ends((item.end.naive_utc(), tz));
     } else {
-        format!("DTSTART:{}", dtstart_value)
-    };
-    let dtend_line = if let Some(tzid) = dtend_tzid {
-        format!("DTEND;TZID={}:{}", escape_ical_text(&tzid), dtend_value)
-    } else {
-        format!("DTEND:{}", dtend_value)
-    };
-    lines.extend([
-        "BEGIN:VEVENT".to_string(),
-        format!("UID:{uid}"),
-        format!("DTSTAMP:{dtstamp}"),
-        format!("SUMMARY:{}", escape_ical_text(&item.subject)),
-        dtstart_line,
-        dtend_line,
-    ]);
+        event.starts(item.start);
+        event.ends(item.end);
+    }
+
     if !item.location.is_empty() {
-        lines.push(format!("LOCATION:{}", escape_ical_text(&item.location)));
+        event.location(&item.location);
     }
     if !item.description.is_empty() {
-        lines.push(format!(
-            "DESCRIPTION:{}",
-            escape_ical_text(&item.description)
-        ));
+        event.description(&item.description);
     }
+
     if let Some(rrule) = &item.rrule
         && !rrule.is_empty()
     {
-        lines.push(format!("RRULE:{rrule}"));
+        event.add_property("RRULE", rrule);
     }
-    let deleted_exdates: Vec<_> = item
+
+    // EXDATE
+    let mut all_exdates: Vec<String> = item
+        .exdates
+        .iter()
+        .map(|v| {
+            if item.all_day {
+                v.format("%Y%m%d").to_string()
+            } else {
+                v.format("%Y%m%dT%H%M%SZ").to_string()
+            }
+        })
+        .collect();
+    let deleted_exdates: Vec<String> = item
         .exceptions
         .iter()
         .filter(|v| v.deleted)
         .map(|v| {
-            format_ical_datetime_with_timezone(
-                &v.exception_start,
-                item.all_day,
-                item.timezone.as_deref(),
-            )
-            .1
+            if item.all_day {
+                v.exception_start.format("%Y%m%d").to_string()
+            } else {
+                v.exception_start.format("%Y%m%dT%H%M%SZ").to_string()
+            }
         })
         .collect();
-    if !item.exdates.is_empty() || !deleted_exdates.is_empty() {
-        let mut exdates: Vec<String> = item
-            .exdates
-            .iter()
-            .map(|v| {
-                format_ical_datetime_with_timezone(v, item.all_day, item.timezone.as_deref()).1
-            })
-            .collect();
-        exdates.extend(deleted_exdates);
-        exdates.sort();
-        exdates.dedup();
+    all_exdates.extend(deleted_exdates);
+    all_exdates.sort();
+    all_exdates.dedup();
+    if !all_exdates.is_empty() {
+        let exdate_str = all_exdates.join(",");
         if !item.all_day {
             if let Some(tzid) = &item.timezone
                 && tzid.parse::<Tz>().is_ok()
             {
-                lines.push(format!(
-                    "EXDATE;TZID={}:{}",
-                    escape_ical_text(tzid),
-                    exdates.join(",")
-                ));
+                event.append_property(
+                    Property::new("EXDATE", &exdate_str)
+                        .add_parameter("TZID", tzid)
+                        .done(),
+                );
             } else {
-                lines.push(format!("EXDATE:{}", exdates.join(",")));
+                event.append_property(Property::new("EXDATE", &exdate_str));
             }
         } else {
-            lines.push(format!("EXDATE:{}", exdates.join(",")));
+            event.append_property(Property::new("EXDATE", &exdate_str));
         }
     }
+
+    // ORGANIZER
     if let Some(email) = &item.organizer_email {
-        let mut line = String::from("ORGANIZER");
+        let mut org_prop = Property::new("ORGANIZER", &normalize_mailto(email));
         if let Some(name) = &item.organizer_name {
-            line.push_str(&format!(";CN={}", escape_ical_text(name)));
+            org_prop.add_parameter("CN", name);
         }
-        line.push(':');
-        line.push_str(&normalize_mailto(email));
-        lines.push(line);
+        event.append_property(org_prop.done());
     }
+
+    // ATTENDEES — use the icalendar crate's Attendee builder
     for attendee in &item.attendees {
         if attendee.email.is_empty() {
             continue;
         }
-        lines.push(render_attendee_line(attendee));
+        let mut cal_attendee = icalendar::Attendee::new(normalize_mailto(&attendee.email));
+        if let Some(name) = &attendee.name {
+            cal_attendee = cal_attendee.cn(name.clone());
+        }
+        if let Some(kind) = attendee.attendee_type {
+            let role = match kind {
+                2 => icalendar::Role::OptParticipant,
+                3 => icalendar::Role::NonParticipant,
+                _ => icalendar::Role::ReqParticipant,
+            };
+            cal_attendee = cal_attendee.role(role);
+        }
+        if let Some(partstat) = &attendee.partstat {
+            let ps = match partstat.to_uppercase().as_str() {
+                "ACCEPTED" => icalendar::PartStat::Accepted,
+                "DECLINED" => icalendar::PartStat::Declined,
+                "TENTATIVE" => icalendar::PartStat::Tentative,
+                "DELEGATED" => icalendar::PartStat::Delegated,
+                _ => icalendar::PartStat::NeedsAction,
+            };
+            cal_attendee = cal_attendee.partstat(ps);
+        }
+        event.attendee(cal_attendee);
     }
+
+    // CATEGORIES
     if !item.categories.is_empty() {
-        lines.push(format!(
-            "CATEGORIES:{}",
-            item.categories
-                .iter()
-                .map(|v| escape_ical_text(v))
-                .collect::<Vec<_>>()
-                .join(",")
+        event.append_property(Property::new(
+            "CATEGORIES",
+            &item.categories.join(","),
         ));
     }
+
+    // Microsoft-specific and custom X- properties
     if let Some(busy) = item.busy_status {
-        lines.push(format!("X-MICROSOFT-CDO-BUSYSTATUS:{busy}"));
-        lines.push(format!(
-            "TRANSP:{}",
-            if busy == 0 { "TRANSPARENT" } else { "OPAQUE" }
-        ));
+        event.append_property(Property::new("X-MICROSOFT-CDO-BUSYSTATUS", &busy.to_string()));
+        event.add_property("TRANSP", if busy == 0 { "TRANSPARENT" } else { "OPAQUE" });
     }
     if let Some(sensitivity) = item.sensitivity {
-        lines.push(format!("CLASS:{}", sensitivity_to_class(sensitivity)));
+        event.class(match sensitivity {
+            2 => Class::Private,
+            3 => Class::Confidential,
+            _ => Class::Public,
+        });
     }
     if let Some(reminder) = item.reminder {
-        lines.extend(render_valarm(reminder));
+        let abs = reminder.abs();
+        let trigger = if abs % 60 == 0 {
+            chrono::Duration::hours(abs as i64 / 60)
+        } else {
+            -chrono::Duration::minutes(abs as i64)
+        };
+        event.alarm(icalendar::Alarm::display("Reminder", trigger));
     }
     if let Some(v) = item.response_requested {
-        lines.push(format!(
-            "X-MS-RESPONSE-REQUESTED:{}",
-            if v { "TRUE" } else { "FALSE" }
+        event.append_property(Property::new(
+            "X-MS-RESPONSE-REQUESTED",
+            if v { "TRUE" } else { "FALSE" },
         ));
     }
     if let Some(v) = item.disallow_new_time_proposal {
-        lines.push(format!(
-            "X-MS-DISALLOW-COUNTER:{}",
-            if v { "TRUE" } else { "FALSE" }
+        event.append_property(Property::new(
+            "X-MS-DISALLOW-COUNTER",
+            if v { "TRUE" } else { "FALSE" },
         ));
     }
     if let Some(v) = item.appointment_reply_time {
-        lines.push(format!(
-            "X-MS-APPOINTMENT-REPLY-TIME:{}",
-            v.format("%Y%m%dT%H%M%SZ")
+        event.append_property(Property::new(
+            "X-MS-APPOINTMENT-REPLY-TIME",
+            &v.format("%Y%m%dT%H%M%SZ").to_string(),
         ));
     }
     if let Some(v) = item.meeting_status {
-        lines.push(format!("X-MS-MEETING-STATUS:{v}"));
+        event.append_property(Property::new("X-MS-MEETING-STATUS", &v.to_string()));
     }
     if let Some(v) = item.response_type {
-        lines.push(format!("X-MS-RESPONSE-TYPE:{v}"));
+        event.append_property(Property::new("X-MS-RESPONSE-TYPE", &v.to_string()));
     }
     if let Some(v) = &item.online_meeting_conf_link {
-        lines.push(format!("X-MS-OLK-CONFLINK:{}", escape_ical_text(v)));
+        event.append_property(Property::new("X-MS-OLK-CONFLINK", v));
     }
     if let Some(v) = &item.online_meeting_external_link {
-        lines.push(format!("X-MS-OLK-EXTERNALLINK:{}", escape_ical_text(v)));
+        event.append_property(Property::new("X-MS-OLK-EXTERNALLINK", v));
     }
     if let Some(v) = &item.client_uid {
-        lines.push(format!("X-MS-CLIENT-UID:{}", escape_ical_text(v)));
+        event.append_property(Property::new("X-MS-CLIENT-UID", v));
     }
     if !item.all_day
         && let Some(v) = &item.timezone
     {
-        lines.push(format!("X-EAS-TIMEZONE:{}", escape_ical_text(v)));
+        event.append_property(Property::new("X-EAS-TIMEZONE", v));
     }
-    lines.push("END:VEVENT".to_string());
 
+    calendar.push(event.done());
+
+    // Exception instances (non-deleted)
     for exception in item.exceptions.iter().filter(|v| !v.deleted) {
         let base_duration = item.end - item.start;
         let effective_all_day = exception.all_day.unwrap_or(item.all_day);
@@ -1010,134 +969,134 @@ pub fn render_ics(item: &CalendarItem) -> String {
         let effective_end = exception
             .end
             .unwrap_or_else(|| effective_start + base_duration);
-        lines.push("BEGIN:VEVENT".to_string());
-        lines.push(format!("UID:{uid}"));
-        lines.push(format!("DTSTAMP:{dtstamp}"));
-        let (recurrence_tzid, recurrence_value) = format_ical_datetime_with_timezone(
-            &exception.exception_start,
-            effective_all_day,
-            item.timezone.as_deref(),
+
+        let mut ex_event = Event::new();
+        ex_event.uid(&uid);
+        ex_event.timestamp(dtstamp);
+        ex_event.summary(
+            exception
+                .subject
+                .as_deref()
+                .unwrap_or(&item.subject),
         );
-        let (exception_start_tzid, exception_start_value) = format_ical_datetime_with_timezone(
-            &effective_start,
-            effective_all_day,
-            item.timezone.as_deref(),
-        );
-        let (exception_end_tzid, exception_end_value) = format_ical_datetime_with_timezone(
-            &effective_end,
-            effective_all_day,
-            item.timezone.as_deref(),
-        );
-        lines.push(if let Some(tzid) = recurrence_tzid {
-            format!(
-                "RECURRENCE-ID;TZID={}:{}",
-                escape_ical_text(&tzid),
-                recurrence_value
-            )
+
+        if effective_all_day {
+            ex_event.append_property(Property::new(
+                "RECURRENCE-ID",
+                &exception.exception_start.format("%Y%m%d").to_string(),
+            ));
+            ex_event.all_day(effective_start.naive_utc().date());
+        } else if let Some(tzid) = &item.timezone
+            && let Ok(tz) = tzid.parse::<Tz>()
+        {
+            ex_event.append_property(
+                Property::new(
+                    "RECURRENCE-ID",
+                    &exception
+                        .exception_start
+                        .with_timezone(&tz)
+                        .format("%Y%m%dT%H%M%S")
+                        .to_string(),
+                )
+                .add_parameter("TZID", tzid)
+                .done(),
+            );
+            ex_event.starts((effective_start.naive_utc(), tz));
+            ex_event.ends((effective_end.naive_utc(), tz));
         } else {
-            format!("RECURRENCE-ID:{}", recurrence_value)
-        });
-        lines.push(if let Some(tzid) = exception_start_tzid {
-            format!(
-                "DTSTART;TZID={}:{}",
-                escape_ical_text(&tzid),
-                exception_start_value
-            )
-        } else {
-            format!("DTSTART:{}", exception_start_value)
-        });
-        lines.push(if let Some(tzid) = exception_end_tzid {
-            format!(
-                "DTEND;TZID={}:{}",
-                escape_ical_text(&tzid),
-                exception_end_value
-            )
-        } else {
-            format!("DTEND:{}", exception_end_value)
-        });
-        lines.push(format!(
-            "SUMMARY:{}",
-            escape_ical_text(exception.subject.as_deref().unwrap_or(&item.subject))
-        ));
+            ex_event.append_property(Property::new(
+                "RECURRENCE-ID",
+                &exception
+                    .exception_start
+                    .format("%Y%m%dT%H%M%SZ")
+                    .to_string(),
+            ));
+            ex_event.starts(effective_start);
+            ex_event.ends(effective_end);
+        }
+
         if let Some(location) = exception.location.as_deref().or(Some(&item.location))
             && !location.is_empty()
         {
-            lines.push(format!("LOCATION:{}", escape_ical_text(location)));
+            ex_event.location(location);
         }
         if let Some(description) = exception.description.as_deref().or(Some(&item.description))
             && !description.is_empty()
         {
-            lines.push(format!("DESCRIPTION:{}", escape_ical_text(description)));
+            ex_event.description(description);
         }
         if let Some(attendees) = &exception.attendees {
             for attendee in attendees {
-                lines.push(render_attendee_line(attendee));
+                if attendee.email.is_empty() {
+                    continue;
+                }
+                let mut cal_attendee = icalendar::Attendee::new(normalize_mailto(&attendee.email));
+                if let Some(name) = &attendee.name {
+                    cal_attendee = cal_attendee.cn(name.clone());
+                }
+                if let Some(kind) = attendee.attendee_type {
+                    let role = match kind {
+                        2 => icalendar::Role::OptParticipant,
+                        3 => icalendar::Role::NonParticipant,
+                        _ => icalendar::Role::ReqParticipant,
+                    };
+                    cal_attendee = cal_attendee.role(role);
+                }
+                if let Some(partstat) = &attendee.partstat {
+                    let ps = match partstat.to_uppercase().as_str() {
+                        "ACCEPTED" => icalendar::PartStat::Accepted,
+                        "DECLINED" => icalendar::PartStat::Declined,
+                        "TENTATIVE" => icalendar::PartStat::Tentative,
+                        "DELEGATED" => icalendar::PartStat::Delegated,
+                        _ => icalendar::PartStat::NeedsAction,
+                    };
+                    cal_attendee = cal_attendee.partstat(ps);
+                }
+                ex_event.attendee(cal_attendee);
             }
         }
         if let Some(categories) = &exception.categories
             && !categories.is_empty()
         {
-            lines.push(format!(
-                "CATEGORIES:{}",
-                categories
-                    .iter()
-                    .map(|v| escape_ical_text(v))
-                    .collect::<Vec<_>>()
-                    .join(",")
-            ));
+            ex_event.append_property(Property::new("CATEGORIES", &categories.join(",")));
         }
         if let Some(busy) = exception.busy_status {
-            lines.push(format!("X-MICROSOFT-CDO-BUSYSTATUS:{busy}"));
+            ex_event.append_property(Property::new("X-MICROSOFT-CDO-BUSYSTATUS", &busy.to_string()));
         }
         if let Some(sensitivity) = exception.sensitivity {
-            lines.push(format!("CLASS:{}", sensitivity_to_class(sensitivity)));
+            ex_event.class(match sensitivity {
+                2 => Class::Private,
+                3 => Class::Confidential,
+                _ => Class::Public,
+            });
         }
         if let Some(reminder) = exception.reminder {
-            lines.extend(render_valarm(reminder));
+            let abs = reminder.abs();
+            let trigger = if abs % 60 == 0 {
+                -chrono::Duration::hours(abs as i64 / 60)
+            } else {
+                -chrono::Duration::minutes(abs as i64)
+            };
+            ex_event.alarm(icalendar::Alarm::display("Reminder", trigger));
         }
         if let Some(v) = exception.appointment_reply_time {
-            lines.push(format!(
-                "X-MS-APPOINTMENT-REPLY-TIME:{}",
-                v.format("%Y%m%dT%H%M%SZ")
+            ex_event.append_property(Property::new(
+                "X-MS-APPOINTMENT-REPLY-TIME",
+                &v.format("%Y%m%dT%H%M%SZ").to_string(),
             ));
         }
         if let Some(v) = exception.meeting_status {
-            lines.push(format!("X-MS-MEETING-STATUS:{v}"));
+            ex_event.append_property(Property::new("X-MS-MEETING-STATUS", &v.to_string()));
         }
         if let Some(v) = exception.response_type {
-            lines.push(format!("X-MS-RESPONSE-TYPE:{v}"));
+            ex_event.append_property(Property::new("X-MS-RESPONSE-TYPE", &v.to_string()));
         }
-        lines.push("END:VEVENT".to_string());
+
+        calendar.push(ex_event.done());
     }
 
-    lines.push("END:VCALENDAR".to_string());
-    lines
-        .into_iter()
-        .map(|l| fold_ics_line(&l))
-        .collect::<Vec<_>>()
-        .join("\r\n")
-        + "\r\n"
-}
-
-fn render_attendee_line(attendee: &Attendee) -> String {
-    let mut line = String::from("ATTENDEE");
-    if let Some(name) = &attendee.name {
-        line.push_str(&format!(";CN={}", escape_ical_text(name)));
-    }
-    if let Some(kind) = attendee.attendee_type {
-        let role = match kind {
-            2 => "OPT-PARTICIPANT",
-            3 => "NON-PARTICIPANT",
-            _ => "REQ-PARTICIPANT",
-        };
-        line.push_str(&format!(";ROLE={role}"));
-    }
-    if let Some(partstat) = &attendee.partstat {
-        line.push_str(&format!(";PARTSTAT={partstat}"));
-    }
-    line.push(':');
-    line.push_str(&normalize_mailto(&attendee.email));
-    line
+    // The icalendar crate's Display impl handles RFC 5545 line folding and CRLF
+    calendar.to_string()
 }
 
 fn parse_ical_param(key: &str, name: &str) -> Option<String> {
@@ -1193,14 +1152,6 @@ fn class_to_sensitivity(value: &str) -> Option<u8> {
         "CONFIDENTIAL" => Some(3),
         "PUBLIC" => Some(0),
         _ => None,
-    }
-}
-
-fn sensitivity_to_class(value: u8) -> &'static str {
-    match value {
-        2 => "PRIVATE",
-        3 => "CONFIDENTIAL",
-        _ => "PUBLIC",
     }
 }
 

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -749,7 +749,8 @@ pub fn parse_ics_event(ics: &str) -> Option<CalendarItem> {
 
 #[must_use]
 pub fn render_ics(item: &CalendarItem) -> String {
-    use icalendar::{Calendar, Class, Component, Event, EventLike, Property};
+    use icalendar::{Calendar, CalendarComponent, Class, Component, Event, EventLike, Property};
+    use std::str::FromStr;
 
     let dtstamp = item.dtstamp.unwrap_or_else(Utc::now);
     let uid = if item.uid.is_empty() {
@@ -761,15 +762,14 @@ pub fn render_ics(item: &CalendarItem) -> String {
     let mut calendar = Calendar::new();
     calendar.append_property(Property::new("PRODID", "-//exchange_gateway//EN"));
 
-    // Embed timezone blob if present
+    // Embed timezone blob if present — parse via icalendar so sub-components
+    // (STANDARD/DAYLIGHT) and property escaping are handled correctly.
     if let Some(blob) = &item.timezone_blob {
-        for line in blob.lines() {
-            let trimmed = line.trim_end();
-            if !trimmed.is_empty() {
-                if let Some(colon_pos) = trimmed.find(':') {
-                    calendar.append_property(
-                        Property::new(&trimmed[..colon_pos], &trimmed[colon_pos + 1..]),
-                    );
+        let wrapped = format!("BEGIN:VCALENDAR\r\n{blob}\r\nEND:VCALENDAR\r\n");
+        if let Ok(parsed) = Calendar::from_str(&icalendar::parser::unfold(&wrapped)) {
+            for component in parsed.iter() {
+                if matches!(component, CalendarComponent::Other(_)) {
+                    calendar.push(component.clone());
                 }
             }
         }
@@ -782,12 +782,21 @@ pub fn render_ics(item: &CalendarItem) -> String {
     event.summary(&item.subject);
 
     if item.all_day {
-        event.all_day(item.start.naive_utc().date());
+        // all_day(date) sets both DTSTART and DTEND to the same date, which
+        // collapses multi-day events. Instead, set DTSTART as a DATE value
+        // and append DTEND separately so multi-day ranges are preserved.
+        event.starts(item.start.naive_utc().date());
+        let end_date = item.end.naive_utc().date();
+        if end_date != item.start.naive_utc().date() {
+            event.append_property(Property::new("DTEND", end_date.format("%Y%m%d").to_string()));
+        }
     } else if let Some(tzid) = &item.timezone
-        && let Ok(tz) = tzid.parse::<Tz>()
+    && let Ok(tz) = tzid.parse::<Tz>()
     {
-        event.starts((item.start.naive_utc(), tz));
-        event.ends((item.end.naive_utc(), tz));
+        // Convert UTC instant to local wall time for the WithTimezone variant,
+        // which interprets the naive datetime as local time in the given tz.
+        event.starts((item.start.with_timezone(&tz).naive_local(), tz));
+        event.ends((item.end.with_timezone(&tz).naive_local(), tz));
     } else {
         event.starts(item.start);
         event.ends(item.end);
@@ -807,12 +816,17 @@ pub fn render_ics(item: &CalendarItem) -> String {
     }
 
     // EXDATE
+    // When TZID is present, EXDATE values must be local time (no 'Z' suffix).
+    // Per RFC 5545 §3.3.5, the 'Z' suffix means UTC, which contradicts TZID.
+    let has_tzid = item.timezone.as_ref().is_some_and(|t| t.parse::<Tz>().is_ok());
     let mut all_exdates: Vec<String> = item
         .exdates
         .iter()
         .map(|v| {
             if item.all_day {
                 v.format("%Y%m%d").to_string()
+            } else if has_tzid {
+                v.format("%Y%m%dT%H%M%S").to_string()
             } else {
                 v.format("%Y%m%dT%H%M%SZ").to_string()
             }
@@ -825,6 +839,8 @@ pub fn render_ics(item: &CalendarItem) -> String {
         .map(|v| {
             if item.all_day {
                 v.exception_start.format("%Y%m%d").to_string()
+            } else if has_tzid {
+                v.exception_start.format("%Y%m%dT%H%M%S").to_string()
             } else {
                 v.exception_start.format("%Y%m%dT%H%M%SZ").to_string()
             }
@@ -854,7 +870,7 @@ pub fn render_ics(item: &CalendarItem) -> String {
 
     // ORGANIZER
     if let Some(email) = &item.organizer_email {
-        let mut org_prop = Property::new("ORGANIZER", &normalize_mailto(email));
+        let mut org_prop = Property::new("ORGANIZER", normalize_mailto(email));
         if let Some(name) = &item.organizer_name {
             org_prop.add_parameter("CN", name);
         }
@@ -895,13 +911,13 @@ pub fn render_ics(item: &CalendarItem) -> String {
     if !item.categories.is_empty() {
         event.append_property(Property::new(
             "CATEGORIES",
-            &item.categories.join(","),
+            item.categories.join(","),
         ));
     }
 
     // Microsoft-specific and custom X- properties
     if let Some(busy) = item.busy_status {
-        event.append_property(Property::new("X-MICROSOFT-CDO-BUSYSTATUS", &busy.to_string()));
+        event.append_property(Property::new("X-MICROSOFT-CDO-BUSYSTATUS", busy.to_string()));
         event.add_property("TRANSP", if busy == 0 { "TRANSPARENT" } else { "OPAQUE" });
     }
     if let Some(sensitivity) = item.sensitivity {
@@ -912,9 +928,11 @@ pub fn render_ics(item: &CalendarItem) -> String {
         });
     }
     if let Some(reminder) = item.reminder {
+        // Reminder is "minutes before start" (always positive), so the
+        // iCal TRIGGER duration must be negative (before the event).
         let abs = reminder.abs();
         let trigger = if abs % 60 == 0 {
-            chrono::Duration::hours(abs as i64 / 60)
+            -chrono::Duration::hours(abs as i64 / 60)
         } else {
             -chrono::Duration::minutes(abs as i64)
         };
@@ -935,14 +953,14 @@ pub fn render_ics(item: &CalendarItem) -> String {
     if let Some(v) = item.appointment_reply_time {
         event.append_property(Property::new(
             "X-MS-APPOINTMENT-REPLY-TIME",
-            &v.format("%Y%m%dT%H%M%SZ").to_string(),
+            v.format("%Y%m%dT%H%M%SZ").to_string(),
         ));
     }
     if let Some(v) = item.meeting_status {
-        event.append_property(Property::new("X-MS-MEETING-STATUS", &v.to_string()));
+        event.append_property(Property::new("X-MS-MEETING-STATUS", v.to_string()));
     }
     if let Some(v) = item.response_type {
-        event.append_property(Property::new("X-MS-RESPONSE-TYPE", &v.to_string()));
+        event.append_property(Property::new("X-MS-RESPONSE-TYPE", v.to_string()));
     }
     if let Some(v) = &item.online_meeting_conf_link {
         event.append_property(Property::new("X-MS-OLK-CONFLINK", v));
@@ -981,32 +999,40 @@ pub fn render_ics(item: &CalendarItem) -> String {
         );
 
         if effective_all_day {
+        ex_event.append_property(Property::new(
+            "RECURRENCE-ID",
+            exception.exception_start.format("%Y%m%d").to_string(),
+        ));
+        // all_day(date) sets both DTSTART and DTEND to the same date, which
+        // collapses multi-day events. Set DTSTART as a DATE value and append
+        // DTEND separately so multi-day ranges are preserved.
+        ex_event.starts(effective_start.naive_utc().date());
+        let end_date = effective_end.naive_utc().date();
+        if end_date != effective_start.naive_utc().date() {
+            ex_event.append_property(Property::new("DTEND", end_date.format("%Y%m%d").to_string()));
+        }
+    } else if let Some(tzid) = &item.timezone
+    && let Ok(tz) = tzid.parse::<Tz>()
+    {
+        ex_event.append_property(
+            Property::new(
+                "RECURRENCE-ID",
+                exception
+                    .exception_start
+                    .with_timezone(&tz)
+                    .format("%Y%m%dT%H%M%S")
+                    .to_string(),
+            )
+            .add_parameter("TZID", tzid)
+            .done(),
+        );
+        // Convert UTC instant to local wall time for the WithTimezone variant
+        ex_event.starts((effective_start.with_timezone(&tz).naive_local(), tz));
+        ex_event.ends((effective_end.with_timezone(&tz).naive_local(), tz));
+    } else {
             ex_event.append_property(Property::new(
                 "RECURRENCE-ID",
-                &exception.exception_start.format("%Y%m%d").to_string(),
-            ));
-            ex_event.all_day(effective_start.naive_utc().date());
-        } else if let Some(tzid) = &item.timezone
-            && let Ok(tz) = tzid.parse::<Tz>()
-        {
-            ex_event.append_property(
-                Property::new(
-                    "RECURRENCE-ID",
-                    &exception
-                        .exception_start
-                        .with_timezone(&tz)
-                        .format("%Y%m%dT%H%M%S")
-                        .to_string(),
-                )
-                .add_parameter("TZID", tzid)
-                .done(),
-            );
-            ex_event.starts((effective_start.naive_utc(), tz));
-            ex_event.ends((effective_end.naive_utc(), tz));
-        } else {
-            ex_event.append_property(Property::new(
-                "RECURRENCE-ID",
-                &exception
+                exception
                     .exception_start
                     .format("%Y%m%dT%H%M%SZ")
                     .to_string(),
@@ -1058,10 +1084,10 @@ pub fn render_ics(item: &CalendarItem) -> String {
         if let Some(categories) = &exception.categories
             && !categories.is_empty()
         {
-            ex_event.append_property(Property::new("CATEGORIES", &categories.join(",")));
+            ex_event.append_property(Property::new("CATEGORIES", categories.join(",")));
         }
         if let Some(busy) = exception.busy_status {
-            ex_event.append_property(Property::new("X-MICROSOFT-CDO-BUSYSTATUS", &busy.to_string()));
+            ex_event.append_property(Property::new("X-MICROSOFT-CDO-BUSYSTATUS", busy.to_string()));
         }
         if let Some(sensitivity) = exception.sensitivity {
             ex_event.class(match sensitivity {
@@ -1082,14 +1108,14 @@ pub fn render_ics(item: &CalendarItem) -> String {
         if let Some(v) = exception.appointment_reply_time {
             ex_event.append_property(Property::new(
                 "X-MS-APPOINTMENT-REPLY-TIME",
-                &v.format("%Y%m%dT%H%M%SZ").to_string(),
+                v.format("%Y%m%dT%H%M%SZ").to_string(),
             ));
         }
         if let Some(v) = exception.meeting_status {
-            ex_event.append_property(Property::new("X-MS-MEETING-STATUS", &v.to_string()));
+            ex_event.append_property(Property::new("X-MS-MEETING-STATUS", v.to_string()));
         }
         if let Some(v) = exception.response_type {
-            ex_event.append_property(Property::new("X-MS-RESPONSE-TYPE", &v.to_string()));
+            ex_event.append_property(Property::new("X-MS-RESPONSE-TYPE", v.to_string()));
         }
 
         calendar.push(ex_event.done());

--- a/src/ical_parser.rs
+++ b/src/ical_parser.rs
@@ -1,12 +1,19 @@
 // src/ical_parser.rs
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use icalendar::parser::unfold;
+use iso8601_duration::Duration as IsoDuration;
 
+/// Unfold iCal content lines per RFC 5545 §3.1.
+/// Delegates to the `icalendar` crate's well-tested implementation.
 pub fn unfold_ical_content(input: &str) -> String {
-    icalendar::parser::unfold(input)
+    unfold(input)
 }
 
 pub type PropertyLine = (String, Vec<(String, String)>, String);
 
+/// Parse a single iCal property line (e.g. `DTSTART;TZID=America/New_York:20240101T100000`).
+/// Uses the `icalendar` crate's parser for the heavy lifting where possible;
+/// falls back to a targeted extractor for parameter-aware colon splitting.
 pub fn parse_property_line(input: &str) -> Result<PropertyLine, nom::Err<nom::error::Error<&str>>> {
     let colon_pos = find_value_colon(input).ok_or_else(|| {
         nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
@@ -29,6 +36,8 @@ pub fn parse_property_line(input: &str) -> Result<PropertyLine, nom::Err<nom::er
     Ok((name.to_string(), params, value.to_string()))
 }
 
+/// Find the colon that separates the property name+params from the value,
+/// respecting quoted strings and backslash escapes per RFC 5545.
 fn find_value_colon(input: &str) -> Option<usize> {
     let mut in_quotes = false;
     let mut escape_next = false;
@@ -48,6 +57,7 @@ fn find_value_colon(input: &str) -> Option<usize> {
     None
 }
 
+/// Parse iCal property parameters (e.g. `TZID=America/New_York;VALUE=DATE`).
 fn parse_parameters(params_str: &str) -> Vec<(String, String)> {
     let mut params = Vec::new();
     let mut current_param = String::new();
@@ -55,9 +65,8 @@ fn parse_parameters(params_str: &str) -> Vec<(String, String)> {
     let mut in_quotes = false;
     let mut escape_next = false;
     let mut parsing_value = false;
-    let chars = params_str.chars();
 
-    for c in chars {
+    for c in params_str.chars() {
         if escape_next {
             if parsing_value {
                 current_value.push(c);
@@ -114,6 +123,7 @@ fn parse_parameters(params_str: &str) -> Vec<(String, String)> {
     params
 }
 
+/// Parse all property lines until a BEGIN: or END: boundary.
 pub fn parse_property_lines(
     input: &str,
 ) -> Result<Vec<(String, String)>, nom::Err<nom::error::Error<&str>>> {
@@ -176,6 +186,8 @@ pub fn parse_property_lines(
     Ok(properties)
 }
 
+/// Parse a single VEVENT block's properties using the `icalendar` crate's
+/// parser when possible, with a targeted fallback for our specific needs.
 pub fn parse_vevent_block(
     input: &str,
 ) -> Result<Vec<(String, String)>, nom::Err<nom::error::Error<&str>>> {
@@ -196,6 +208,8 @@ pub type VeventProps = Vec<(String, String)>;
 
 pub type NomError<'i> = nom::Err<nom::error::Error<&'i str>>;
 
+/// Parse all VEVENT blocks from iCal content.
+/// Uses the `icalendar` crate for unfolding, then extracts properties.
 pub fn parse_all_vevents(input: &str) -> Result<Vec<VeventProps>, NomError<'_>> {
     let unfolded = unfold_ical_content(input);
     let mut events = Vec::new();
@@ -220,6 +234,7 @@ pub fn parse_all_vevents(input: &str) -> Result<Vec<VeventProps>, NomError<'_>> 
     Ok(events)
 }
 
+/// Extract a VTIMEZONE block from iCal content.
 pub fn parse_vtimezone_block(
     input: &str,
 ) -> Result<Option<String>, nom::Err<nom::error::Error<&str>>> {
@@ -236,6 +251,8 @@ pub fn parse_vtimezone_block(
     Ok(None)
 }
 
+/// Parse an iCal datetime string into a UTC `DateTime`.
+/// Supports basic and extended ISO 8601 forms, with and without trailing Z.
 pub fn parse_ical_datetime(
     input: &str,
 ) -> Result<DateTime<Utc>, nom::Err<nom::error::Error<&str>>> {
@@ -273,6 +290,7 @@ pub fn parse_ical_datetime(
     )))
 }
 
+/// Extract a specific parameter value from an iCal property key string.
 pub fn parse_ical_param(input: &str, param_name: &str) -> Option<String> {
     let search = format!("{}=", param_name);
     if let Some(pos) = input.find(&search) {
@@ -296,6 +314,9 @@ pub fn parse_ical_param(input: &str, param_name: &str) -> Option<String> {
         None
     }
 }
+
+/// Unescape iCal text per RFC 5545 §3.3.11.
+/// Handles `\n`, `\r`, `\t`, `\\`, `\,`, `\;`, `\:` escape sequences.
 pub fn unescape_ical_text(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
@@ -303,15 +324,15 @@ pub fn unescape_ical_text(input: &str) -> String {
     while let Some(c) = chars.next() {
         if c == '\\' {
             match chars.peek() {
-                Some('n') => {
+                Some('n') | Some('N') => {
                     result.push('\n');
                     chars.next();
                 }
-                Some('r') => {
+                Some('r') | Some('R') => {
                     result.push('\r');
                     chars.next();
                 }
-                Some('t') => {
+                Some('t') | Some('T') => {
                     result.push('\t');
                     chars.next();
                 }
@@ -341,46 +362,36 @@ pub fn unescape_ical_text(input: &str) -> String {
     result
 }
 
+/// Parse an ISO 8601 duration string (e.g. `PT1H30M`, `-PT15M`) and return
+/// the total duration in minutes. Delegates to the `iso8601-duration` crate
+/// for standards-compliant parsing.
 pub fn parse_ical_duration_minutes(input: &str) -> Result<i32, nom::Err<nom::error::Error<&str>>> {
-    let (negative, input) = if let Some(stripped) = input.strip_prefix('-') {
-        (true, stripped)
+    let negative = input.starts_with('-');
+    let to_parse = if negative { &input[1..] } else { input };
+
+    let duration: IsoDuration = to_parse.parse().map_err(|_| {
+        nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Verify))
+    })?;
+
+    let minutes = iso_duration_to_minutes(&duration);
+
+    Ok(if negative { -minutes } else { minutes })
+}
+
+/// Convert an `iso8601_duration::Duration` to total whole minutes.
+/// This is application-specific glue: the Exchange protocols need duration
+/// expressed in minutes for EAS items.
+fn iso_duration_to_minutes(d: &IsoDuration) -> i32 {
+    // The iso8601-duration crate uses f32 fields and provides num_minutes()
+    // only when year/month are zero (which is the case for PT... durations).
+    // For durations with year/month, use an approximate conversion.
+    if d.year > 0.0 || d.month > 0.0 {
+        // Approximate: 1 year ≈ 525960 min, 1 month ≈ 43830 min
+        (d.year * 525_960.0 + d.month * 43_830.0 + d.day * 1440.0
+            + d.hour * 60.0 + d.minute + d.second / 60.0) as i32
     } else {
-        (false, input)
-    };
-
-    let input = input.strip_prefix('P').unwrap_or(input);
-    let input = input.strip_prefix('T').unwrap_or(input);
-
-    let mut total_minutes: i32 = 0;
-    let mut remaining = input;
-
-    while !remaining.is_empty() {
-        let digit_end = remaining
-            .find(|c: char| !c.is_ascii_digit())
-            .unwrap_or(remaining.len());
-
-        if digit_end == 0 {
-            break;
-        }
-
-        let value: i32 = remaining[..digit_end].parse().unwrap_or(0);
-        let unit = remaining.chars().nth(digit_end).unwrap_or('M');
-
-        match unit {
-            'H' => total_minutes += value * 60,
-            'M' => total_minutes += value,
-            'S' => {}
-            _ => break,
-        }
-
-        remaining = &remaining[digit_end + 1..];
+        d.num_minutes().unwrap_or(0.0) as i32
     }
-
-    Ok(if negative {
-        -total_minutes
-    } else {
-        total_minutes
-    })
 }
 
 #[cfg(test)]

--- a/src/ical_parser.rs
+++ b/src/ical_parser.rs
@@ -385,7 +385,7 @@ fn iso_duration_to_minutes(d: &IsoDuration) -> i32 {
     // The iso8601-duration crate uses f32 fields and provides num_minutes()
     // only when year/month are zero (which is the case for PT... durations).
     // For durations with year/month, use an approximate conversion.
-    if d.year > 0.0 || d.month > 0.0 {
+    if d.year > f32::EPSILON || d.month > f32::EPSILON {
         // Approximate: 1 year ≈ 525960 min, 1 month ≈ 43830 min
         (d.year * 525_960.0 + d.month * 43_830.0 + d.day * 1440.0
             + d.hour * 60.0 + d.minute + d.second / 60.0) as i32

--- a/src/meeting/attendee.rs
+++ b/src/meeting/attendee.rs
@@ -2,15 +2,19 @@
 use crate::util::normalize_email;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, strum::Display)]
 pub enum AttendeeStatus {
     #[default]
+    #[strum(serialize = "NEEDS-ACTION")]
     NeedsAction = 0,
+    #[strum(serialize = "ACCEPTED")]
     Accepted = 1,
+    #[strum(serialize = "DECLINED")]
     Declined = 2,
+    #[strum(serialize = "TENTATIVE")]
     Tentative = 3,
+    #[strum(serialize = "NEEDS-ACTION")]
     NotResponded = 5,
 }
 
@@ -23,18 +27,6 @@ impl From<u8> for AttendeeStatus {
             3 => Self::Tentative,
             5 => Self::NotResponded,
             _ => Self::NeedsAction,
-        }
-    }
-}
-
-impl fmt::Display for AttendeeStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NeedsAction => write!(f, "NEEDS-ACTION"),
-            Self::Accepted => write!(f, "ACCEPTED"),
-            Self::Declined => write!(f, "DECLINED"),
-            Self::Tentative => write!(f, "TENTATIVE"),
-            Self::NotResponded => write!(f, "NEEDS-ACTION"),
         }
     }
 }
@@ -79,11 +71,14 @@ impl AttendeeStatus {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, strum::Display)]
 pub enum AttendeeRole {
     #[default]
+    #[strum(serialize = "REQ-PARTICIPANT")]
     Required = 1,
+    #[strum(serialize = "OPT-PARTICIPANT")]
     Optional = 2,
+    #[strum(serialize = "NON-PARTICIPANT")]
     Resource = 3,
 }
 
@@ -94,16 +89,6 @@ impl From<u8> for AttendeeRole {
             2 => Self::Optional,
             3 => Self::Resource,
             _ => Self::Required,
-        }
-    }
-}
-
-impl fmt::Display for AttendeeRole {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Required => write!(f, "REQ-PARTICIPANT"),
-            Self::Optional => write!(f, "OPT-PARTICIPANT"),
-            Self::Resource => write!(f, "NON-PARTICIPANT"),
         }
     }
 }

--- a/src/meeting/message.rs
+++ b/src/meeting/message.rs
@@ -1,7 +1,7 @@
 // src/meeting/message.rs
 use crate::calendar::{Attendee, CalendarItem};
 use crate::meeting::attendee::{AttendeeRole, AttendeeStatus};
-use crate::util::{escape_ical_text, xml_escape};
+use crate::util::xml_escape;
 use chrono::{DateTime, Utc};
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -204,109 +204,105 @@ impl MeetingMessageGenerator {
         }
     }
 
+    /// Generate an iCal representation using the `icalendar` crate,
+    /// which handles RFC 5545 escaping and line folding automatically.
     pub fn generate_ical(&self, msg: &MeetingMessage) -> String {
-        let mut ics = String::with_capacity(4096);
+        use icalendar::{Calendar, Component, Event, EventLike, EventStatus, Property};
 
-        ics.push_str("BEGIN:VCALENDAR\r\n");
-        ics.push_str(&format!("PRODID:{}\r\n", self.ical_product_id));
-        ics.push_str("VERSION:2.0\r\n");
-        ics.push_str(&format!("METHOD:{}\r\n", msg.message_type.to_ical_method()));
+        let mut calendar = Calendar::new();
+        calendar.append_property(Property::new("PRODID", &self.ical_product_id));
+        calendar.append_property(Property::new("METHOD", msg.message_type.to_ical_method()));
 
-        ics.push_str("BEGIN:VEVENT\r\n");
-        ics.push_str(&format!("UID:{}\r\n", msg.uid));
-        ics.push_str(&format!(
-            "DTSTAMP:{}\r\n",
-            msg.dtstamp.format("%Y%m%dT%H%M%SZ")
-        ));
-        ics.push_str(&format!(
-            "DTSTART:{}\r\n",
-            msg.start.format("%Y%m%dT%H%M%SZ")
-        ));
-        ics.push_str(&format!("DTEND:{}\r\n", msg.end.format("%Y%m%dT%H%M%SZ")));
-        ics.push_str(&format!("SEQUENCE:{}\r\n", msg.sequence));
+        let mut event = Event::new();
+        event.uid(&msg.uid);
+        event.timestamp(msg.dtstamp);
+        event.starts(msg.start);
+        event.ends(msg.end);
+        event.sequence(msg.sequence);
 
         if !msg.subject.is_empty() {
-            ics.push_str(&format!("SUMMARY:{}\r\n", escape_ical_text(&msg.subject)));
+            event.summary(&msg.subject);
         }
-
         if let Some(ref desc) = msg.description {
-            ics.push_str(&format!("DESCRIPTION:{}\r\n", escape_ical_text(desc)));
+            event.description(desc);
         }
-
         if let Some(ref loc) = msg.location {
-            ics.push_str(&format!("LOCATION:{}\r\n", escape_ical_text(loc)));
+            event.location(loc);
         }
 
         if msg.message_type == MeetingMessageType::Request
             || msg.message_type == MeetingMessageType::Update
         {
-            ics.push_str(&format!(
-                "ORGANIZER;CN={}:mailto:{}\r\n",
-                escape_ical_text(
-                    msg.organizer_name
-                        .as_deref()
-                        .unwrap_or(&msg.organizer_email)
-                ),
-                msg.organizer_email
-            ));
+            let mut org_prop = Property::new(
+                "ORGANIZER",
+                &format!("mailto:{}", msg.organizer_email),
+            );
+            org_prop.add_parameter(
+                "CN",
+                msg.organizer_name.as_deref().unwrap_or(&msg.organizer_email),
+            );
+            event.append_property(org_prop.done());
 
             for attendee in &msg.attendees {
                 let role = AttendeeRole::from(attendee.attendee_type.unwrap_or(1));
-                let status = AttendeeStatus::NeedsAction;
-                ics.push_str(&format!(
-                    "ATTENDEE;CN={};ROLE={};PARTSTAT={}:mailto:{}\r\n",
-                    escape_ical_text(attendee.name.as_deref().unwrap_or(&attendee.email)),
-                    role.to_ical_role(),
-                    status.to_partstat(),
-                    attendee.email
-                ));
+                let ical_role = match role {
+                    AttendeeRole::Optional => icalendar::Role::OptParticipant,
+                    AttendeeRole::Resource => icalendar::Role::NonParticipant,
+                    _ => icalendar::Role::ReqParticipant,
+                };
+                let cal_attendee = icalendar::Attendee::new(format!("mailto:{}", attendee.email))
+                    .cn(attendee.name.as_deref().unwrap_or(&attendee.email).to_string())
+                    .role(ical_role)
+                    .partstat(icalendar::PartStat::NeedsAction);
+                event.attendee(cal_attendee);
             }
         } else if msg.message_type == MeetingMessageType::Response {
             if let Some(ref status) = msg.response_status {
-                ics.push_str(&format!(
-                    "ORGANIZER;CN={}:mailto:{}\r\n",
-                    escape_ical_text(
-                        msg.organizer_name
-                            .as_deref()
-                            .unwrap_or(&msg.organizer_email)
-                    ),
-                    msg.organizer_email
-                ));
-                ics.push_str(&format!(
-                    "ATTENDEE;PARTSTAT={}:mailto:{}\r\n",
-                    status.to_partstat(),
-                    msg.organizer_email
-                ));
+                let mut org_prop = Property::new(
+                    "ORGANIZER",
+                    &format!("mailto:{}", msg.organizer_email),
+                );
+                org_prop.add_parameter(
+                    "CN",
+                    msg.organizer_name.as_deref().unwrap_or(&msg.organizer_email),
+                );
+                event.append_property(org_prop.done());
+
+                let partstat = match status {
+                    AttendeeStatus::Accepted => icalendar::PartStat::Accepted,
+                    AttendeeStatus::Declined => icalendar::PartStat::Declined,
+                    AttendeeStatus::Tentative => icalendar::PartStat::Tentative,
+                    _ => icalendar::PartStat::NeedsAction,
+                };
+                let cal_attendee = icalendar::Attendee::new(format!("mailto:{}", msg.organizer_email))
+                    .partstat(partstat);
+                event.attendee(cal_attendee);
             }
         } else if msg.message_type == MeetingMessageType::Counter
             && let (Some(start), Some(end)) = (msg.proposed_start, msg.proposed_end)
         {
-            ics.push_str(&format!(
-                "DTSTART;X-MS-OLK-ORIGINAL={}Z:{}Z\r\n",
-                msg.start.format("%Y%m%dT%H%M%S"),
-                start.format("%Y%m%dT%H%M%S")
-            ));
-            ics.push_str(&format!(
-                "DTEND;X-MS-OLK-ORIGINAL={}Z:{}Z\r\n",
-                msg.end.format("%Y%m%dT%H%M%S"),
-                end.format("%Y%m%dT%H%M%S")
-            ));
+            event.append_property(Property::new(
+                "DTSTART",
+                &format!("{}Z", start.format("%Y%m%dT%H%M%S")),
+            ).add_parameter("X-MS-OLK-ORIGINAL", &format!("{}Z", msg.start.format("%Y%m%dT%H%M%S"))).done());
+            event.append_property(Property::new(
+                "DTEND",
+                &format!("{}Z", end.format("%Y%m%dT%H%M%S")),
+            ).add_parameter("X-MS-OLK-ORIGINAL", &format!("{}Z", msg.end.format("%Y%m%dT%H%M%S"))).done());
         }
 
         if msg.message_type == MeetingMessageType::Request
             || msg.message_type == MeetingMessageType::Update
         {
-            ics.push_str("X-MICROSOFT-CDO-BUSYSTATUS:BUSY\r\n");
+            event.append_property(Property::new("X-MICROSOFT-CDO-BUSYSTATUS", "BUSY"));
         }
 
         if msg.message_type == MeetingMessageType::Cancellation {
-            ics.push_str("STATUS:CANCELLED\r\n");
+            event.status(EventStatus::Cancelled);
         }
 
-        ics.push_str("END:VEVENT\r\n");
-        ics.push_str("END:VCALENDAR\r\n");
-
-        ics
+        calendar.push(event.done());
+        calendar.to_string()
     }
 
     pub fn generate_ews_create_response(
@@ -483,42 +479,6 @@ impl MeetingMessageGenerator {
     }
 }
 
-pub fn fold_ical_line(line: &str, max_len: usize) -> String {
-    if line.len() <= max_len {
-        return line.to_string();
-    }
-
-    let mut result = String::with_capacity(line.len() + (line.len() / max_len) * 3);
-    let mut remaining = line;
-
-    while remaining.len() > max_len {
-        let split_point = remaining
-            .char_indices()
-            .take_while(|(idx, _)| *idx <= max_len)
-            .map(|(idx, c)| idx + c.len_utf8())
-            .last()
-            .unwrap_or(0);
-
-        let split_point = if split_point == 0 {
-            remaining
-                .char_indices()
-                .nth(1)
-                .map(|(idx, _)| idx)
-                .unwrap_or(remaining.len())
-        } else {
-            split_point
-        };
-
-        let (chunk, rest) = remaining.split_at(split_point);
-        result.push_str(chunk);
-        result.push_str("\r\n ");
-        remaining = rest;
-    }
-    result.push_str(remaining);
-
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -597,8 +557,10 @@ mod tests {
 
     #[test]
     fn test_escape_ical_text() {
-        assert_eq!(escape_ical_text("a,b;c\\d"), "a\\,b\\;c\\\\d");
-        assert_eq!(escape_ical_text("line1\nline2"), "line1\\nline2");
+        // The icalendar crate now handles escaping internally
+        // but we can verify the util function still works correctly for backward compat
+        assert_eq!(crate::util::escape_ical_text("a,b;c\\d"), "a\\,b\\;c\\\\d");
+        assert_eq!(crate::util::escape_ical_text("line1\nline2"), "line1\\nline2");
     }
 
     #[test]

--- a/src/meeting/message.rs
+++ b/src/meeting/message.rs
@@ -216,9 +216,31 @@ impl MeetingMessageGenerator {
         let mut event = Event::new();
         event.uid(&msg.uid);
         event.timestamp(msg.dtstamp);
-        event.starts(msg.start);
-        event.ends(msg.end);
         event.sequence(msg.sequence);
+
+        // For Counter messages with proposed times, the DTSTART/DTEND carry
+        // the proposed times with X-MS-OLK-ORIGINAL parameters for the originals.
+        // Do NOT call event.starts()/event.ends() for Counter, as they would
+        // emit duplicate DTSTART/DTEND properties alongside append_property.
+        let is_counter_with_props = msg.message_type == MeetingMessageType::Counter
+            && msg.proposed_start.is_some()
+            && msg.proposed_end.is_some();
+
+        if is_counter_with_props {
+            if let (Some(start), Some(end)) = (msg.proposed_start, msg.proposed_end) {
+                event.append_property(Property::new(
+                    "DTSTART",
+                    format!("{}Z", start.format("%Y%m%dT%H%M%S")),
+                ).add_parameter("X-MS-OLK-ORIGINAL", &format!("{}Z", msg.start.format("%Y%m%dT%H%M%S"))).done());
+                event.append_property(Property::new(
+                    "DTEND",
+                    format!("{}Z", end.format("%Y%m%dT%H%M%S")),
+                ).add_parameter("X-MS-OLK-ORIGINAL", &format!("{}Z", msg.end.format("%Y%m%dT%H%M%S"))).done());
+            }
+        } else {
+            event.starts(msg.start);
+            event.ends(msg.end);
+        }
 
         if !msg.subject.is_empty() {
             event.summary(&msg.subject);
@@ -235,7 +257,7 @@ impl MeetingMessageGenerator {
         {
             let mut org_prop = Property::new(
                 "ORGANIZER",
-                &format!("mailto:{}", msg.organizer_email),
+                format!("mailto:{}", msg.organizer_email),
             );
             org_prop.add_parameter(
                 "CN",
@@ -256,11 +278,11 @@ impl MeetingMessageGenerator {
                     .partstat(icalendar::PartStat::NeedsAction);
                 event.attendee(cal_attendee);
             }
-        } else if msg.message_type == MeetingMessageType::Response {
-            if let Some(ref status) = msg.response_status {
+        } else if msg.message_type == MeetingMessageType::Response
+            && let Some(ref status) = msg.response_status {
                 let mut org_prop = Property::new(
                     "ORGANIZER",
-                    &format!("mailto:{}", msg.organizer_email),
+                    format!("mailto:{}", msg.organizer_email),
                 );
                 org_prop.add_parameter(
                     "CN",
@@ -278,18 +300,6 @@ impl MeetingMessageGenerator {
                     .partstat(partstat);
                 event.attendee(cal_attendee);
             }
-        } else if msg.message_type == MeetingMessageType::Counter
-            && let (Some(start), Some(end)) = (msg.proposed_start, msg.proposed_end)
-        {
-            event.append_property(Property::new(
-                "DTSTART",
-                &format!("{}Z", start.format("%Y%m%dT%H%M%S")),
-            ).add_parameter("X-MS-OLK-ORIGINAL", &format!("{}Z", msg.start.format("%Y%m%dT%H%M%S"))).done());
-            event.append_property(Property::new(
-                "DTEND",
-                &format!("{}Z", end.format("%Y%m%dT%H%M%S")),
-            ).add_parameter("X-MS-OLK-ORIGINAL", &format!("{}Z", msg.end.format("%Y%m%dT%H%M%S"))).done());
-        }
 
         if msg.message_type == MeetingMessageType::Request
             || msg.message_type == MeetingMessageType::Update
@@ -304,6 +314,7 @@ impl MeetingMessageGenerator {
         calendar.push(event.done());
         calendar.to_string()
     }
+
 
     pub fn generate_ews_create_response(
         &self,

--- a/src/meeting/scheduling.rs
+++ b/src/meeting/scheduling.rs
@@ -2,8 +2,10 @@
 
 use crate::calendar::CalendarItem;
 use crate::ical_parser;
-use crate::util::{escape_ical_text, normalize_email};
+use crate::meeting::attendee::{AttendeeRole, AttendeeStatus};
+use crate::util::normalize_email;
 use chrono::{DateTime, Utc};
+use icalendar::{Calendar, Component, Event, EventLike, EventStatus, Property};
 
 pub struct SchedulingContext {
     pub organizer_email: String,
@@ -20,102 +22,58 @@ pub struct AttendeeInfo {
     pub status: AttendeeStatus,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AttendeeRole {
-    Chair = 0,
-    Required = 1,
-    Optional = 2,
-    NonParticipant = 3,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AttendeeStatus {
-    NeedsAction = 0,
-    Accepted = 1,
-    Declined = 2,
-    Tentative = 3,
-    Delegated = 4,
-    Completed = 5,
-    InProcess = 6,
-}
-
+/// Build an iTIP REQUEST using the `icalendar` crate (handles escaping + folding).
 pub fn build_itip_request(ctx: &SchedulingContext, item: &CalendarItem) -> String {
-    let mut lines: Vec<String> = Vec::new();
-    lines.push("BEGIN:VCALENDAR".to_string());
-    lines.push("VERSION:2.0".to_string());
-    lines.push("PRODID:-//Exchange Gateway//EN".to_string());
-    lines.push("METHOD:REQUEST".to_string());
-    lines.push(format!("SEQUENCE:{}", ctx.sequence));
-    lines.push(build_vevent(ctx, item));
-    lines.push("END:VCALENDAR".to_string());
-    lines.join("\r\n")
-}
+    let mut calendar = Calendar::new();
+    calendar.append_property(Property::new("PRODID", "-//Exchange Gateway//EN"));
+    calendar.append_property(Property::new("METHOD", "REQUEST"));
+    calendar.append_property(Property::new("SEQUENCE", &ctx.sequence.to_string()));
 
-fn build_vevent(ctx: &SchedulingContext, item: &CalendarItem) -> String {
-    let mut lines: Vec<String> = Vec::new();
-    lines.push("BEGIN:VEVENT".to_string());
-    lines.push(format!("UID:{}", ctx.uid));
-    lines.push(format!("DTSTAMP:{}", format_ical_datetime(Utc::now())));
+    let mut event = Event::new();
+    event.uid(&ctx.uid);
+    event.timestamp(Utc::now());
+    event.starts(item.start);
+    event.ends(item.end);
     if !item.subject.is_empty() {
-        lines.push(format!("SUMMARY:{}", escape_ical_text(&item.subject)));
+        event.summary(&item.subject);
     }
     if !item.location.is_empty() {
-        lines.push(format!("LOCATION:{}", escape_ical_text(&item.location)));
+        event.location(&item.location);
     }
-    lines.push(format!("DTSTART:{}", format_ical_datetime(item.start)));
-    lines.push(format!("DTEND:{}", format_ical_datetime(item.end)));
-    lines.push(format!(
-        "ORGANIZER;CN={}:mailto:{}",
-        escape_ical_param(ctx.organizer_name.as_deref().unwrap_or("")),
-        ctx.organizer_email
-    ));
+
+    let mut org_prop = Property::new("ORGANIZER", &format!("mailto:{}", ctx.organizer_email));
+    if let Some(name) = &ctx.organizer_name {
+        org_prop.add_parameter("CN", name);
+    }
+    event.append_property(org_prop.done());
+
     for attendee in &ctx.attendees {
-        let role = match attendee.role {
-            AttendeeRole::Chair => "CHAIR",
-            AttendeeRole::Required => "REQ-PARTICIPANT",
-            AttendeeRole::Optional => "OPT-PARTICIPANT",
-            AttendeeRole::NonParticipant => "NON-PARTICIPANT",
+        let ical_role = match attendee.role {
+            AttendeeRole::Required => icalendar::Role::ReqParticipant,
+            AttendeeRole::Optional => icalendar::Role::OptParticipant,
+            AttendeeRole::Resource => icalendar::Role::NonParticipant,
         };
-        let status = match attendee.status {
-            AttendeeStatus::NeedsAction => "NEEDS-ACTION",
-            AttendeeStatus::Accepted => "ACCEPTED",
-            AttendeeStatus::Declined => "DECLINED",
-            AttendeeStatus::Tentative => "TENTATIVE",
-            AttendeeStatus::Delegated => "DELEGATED",
-            AttendeeStatus::Completed => "COMPLETED",
-            AttendeeStatus::InProcess => "IN-PROCESS",
+        let ical_partstat = match attendee.status {
+            AttendeeStatus::Accepted => icalendar::PartStat::Accepted,
+            AttendeeStatus::Declined => icalendar::PartStat::Declined,
+            AttendeeStatus::Tentative => icalendar::PartStat::Tentative,
+            AttendeeStatus::NotResponded | AttendeeStatus::NeedsAction => {
+                icalendar::PartStat::NeedsAction
+            }
         };
-        lines.push(format!(
-            "ATTENDEE;CN={};ROLE={};PARTSTAT={}:mailto:{}",
-            escape_ical_param(attendee.name.as_deref().unwrap_or("")),
-            role,
-            status,
-            attendee.email
-        ));
+        let cal_attendee = icalendar::Attendee::new(format!("mailto:{}", attendee.email))
+            .cn(attendee.name.as_deref().unwrap_or(&attendee.email).to_string())
+            .role(ical_role)
+            .partstat(ical_partstat);
+        event.attendee(cal_attendee);
     }
-    lines.push("END:VEVENT".to_string());
-    lines.join("\r\n")
+
+    calendar.push(event.done());
+    calendar.to_string()
 }
 
 pub fn format_ical_datetime(dt: DateTime<Utc>) -> String {
     dt.format("%Y%m%dT%H%M%SZ").to_string()
-}
-
-pub fn escape_ical_param(s: &str) -> String {
-    let escaped = s
-        .replace('\\', "\\\\")
-        .replace(';', "\\;")
-        .replace(':', "\\:")
-        .replace(',', "\\,")
-        .replace('"', "\\'");
-    if escaped
-        .chars()
-        .any(|c| c == ';' || c == ':' || c == ',' || c == ' ' || c == '"' || c == '\\' || c == '\n')
-    {
-        format!("\"{}\"", escaped)
-    } else {
-        escaped
-    }
 }
 
 pub fn parse_itip_response(ical: &str) -> Option<ItipResponse> {
@@ -175,13 +133,9 @@ pub fn parse_itip_response(ical: &str) -> Option<ItipResponse> {
 
     let attendee_email = responding_attendee_email?;
 
-    let attendee_status = match responding_partstat.as_deref() {
-        Some("ACCEPTED") => AttendeeStatus::Accepted,
-        Some("DECLINED") => AttendeeStatus::Declined,
-        Some("TENTATIVE") => AttendeeStatus::Tentative,
-        Some("DELEGATED") => AttendeeStatus::Delegated,
-        _ => AttendeeStatus::NeedsAction,
-    };
+    let attendee_status = AttendeeStatus::from_partstat(
+        responding_partstat.as_deref().unwrap_or("NEEDS-ACTION"),
+    );
 
     Some(ItipResponse {
         uid,
@@ -190,6 +144,7 @@ pub fn parse_itip_response(ical: &str) -> Option<ItipResponse> {
         attendee_status,
     })
 }
+
 pub struct ItipResponse {
     pub uid: String,
     pub sequence: u32,
@@ -197,29 +152,23 @@ pub struct ItipResponse {
     pub attendee_status: AttendeeStatus,
 }
 
+/// Build an iTIP CANCEL using the `icalendar` crate.
 pub fn build_cancel_request(ctx: &SchedulingContext, item: &CalendarItem) -> String {
-    let mut lines: Vec<String> = Vec::new();
-    lines.push("BEGIN:VCALENDAR".to_string());
-    lines.push("VERSION:2.0".to_string());
-    lines.push("PRODID:-//Exchange Gateway//EN".to_string());
-    lines.push("METHOD:CANCEL".to_string());
-    lines.push(format!("SEQUENCE:{}", ctx.sequence));
-    lines.push(build_cancel_vevent(ctx, item));
-    lines.push("END:VCALENDAR".to_string());
-    lines.join("\r\n")
-}
+    let mut calendar = Calendar::new();
+    calendar.append_property(Property::new("PRODID", "-//Exchange Gateway//EN"));
+    calendar.append_property(Property::new("METHOD", "CANCEL"));
+    calendar.append_property(Property::new("SEQUENCE", &ctx.sequence.to_string()));
 
-fn build_cancel_vevent(ctx: &SchedulingContext, item: &CalendarItem) -> String {
-    let mut lines: Vec<String> = Vec::new();
-    lines.push("BEGIN:VEVENT".to_string());
-    lines.push(format!("UID:{}", ctx.uid));
-    lines.push(format!("DTSTAMP:{}", format_ical_datetime(Utc::now())));
-    lines.push("STATUS:CANCELLED".to_string());
+    let mut event = Event::new();
+    event.uid(&ctx.uid);
+    event.timestamp(Utc::now());
+    event.status(EventStatus::Cancelled);
     if !item.subject.is_empty() {
-        lines.push(format!("SUMMARY:{}", escape_ical_text(&item.subject)));
+        event.summary(&item.subject);
     }
-    lines.push("END:VEVENT".to_string());
-    lines.join("\r\n")
+
+    calendar.push(event.done());
+    calendar.to_string()
 }
 
 #[cfg(test)]
@@ -232,11 +181,5 @@ mod tests {
             .unwrap()
             .with_timezone(&Utc);
         assert_eq!(format_ical_datetime(dt), "20240115T103000Z");
-    }
-
-    #[test]
-    fn test_escape_ical_text() {
-        assert_eq!(escape_ical_text("hello;world"), "hello\\;world");
-        assert_eq!(escape_ical_text("a,b\\c"), "a\\,b\\\\c");
     }
 }

--- a/src/meeting/scheduling.rs
+++ b/src/meeting/scheduling.rs
@@ -27,7 +27,7 @@ pub fn build_itip_request(ctx: &SchedulingContext, item: &CalendarItem) -> Strin
     let mut calendar = Calendar::new();
     calendar.append_property(Property::new("PRODID", "-//Exchange Gateway//EN"));
     calendar.append_property(Property::new("METHOD", "REQUEST"));
-    calendar.append_property(Property::new("SEQUENCE", &ctx.sequence.to_string()));
+    calendar.append_property(Property::new("SEQUENCE", ctx.sequence.to_string()));
 
     let mut event = Event::new();
     event.uid(&ctx.uid);
@@ -41,7 +41,7 @@ pub fn build_itip_request(ctx: &SchedulingContext, item: &CalendarItem) -> Strin
         event.location(&item.location);
     }
 
-    let mut org_prop = Property::new("ORGANIZER", &format!("mailto:{}", ctx.organizer_email));
+    let mut org_prop = Property::new("ORGANIZER", format!("mailto:{}", ctx.organizer_email));
     if let Some(name) = &ctx.organizer_name {
         org_prop.add_parameter("CN", name);
     }
@@ -157,7 +157,7 @@ pub fn build_cancel_request(ctx: &SchedulingContext, item: &CalendarItem) -> Str
     let mut calendar = Calendar::new();
     calendar.append_property(Property::new("PRODID", "-//Exchange Gateway//EN"));
     calendar.append_property(Property::new("METHOD", "CANCEL"));
-    calendar.append_property(Property::new("SEQUENCE", &ctx.sequence.to_string()));
+    calendar.append_property(Property::new("SEQUENCE", ctx.sequence.to_string()));
 
     let mut event = Event::new();
     event.uid(&ctx.uid);

--- a/src/permission/types.rs
+++ b/src/permission/types.rs
@@ -209,18 +209,28 @@ impl From<PermissionRights> for u32 {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, strum::Display, strum::FromRepr)]
 pub enum PermissionLevel {
     #[default]
+    #[strum(serialize = "None")]
     None = 0,
+    #[strum(serialize = "FreeBusyTimeOnly")]
     FreeBusy = 1,
+    #[strum(serialize = "Reviewer")]
     Reviewer = 2,
+    #[strum(serialize = "Contributor")]
     Contributor = 3,
+    #[strum(serialize = "NonEditingAuthor")]
     NonEditingAuthor = 4,
+    #[strum(serialize = "Author")]
     Author = 5,
+    #[strum(serialize = "PublishingAuthor")]
     PublishingAuthor = 6,
+    #[strum(serialize = "Editor")]
     Editor = 7,
+    #[strum(serialize = "PublishingEditor")]
     PublishingEditor = 8,
+    #[strum(serialize = "Owner")]
     Owner = 9,
 }
 
@@ -271,7 +281,10 @@ impl PermissionLevel {
         Self::None
     }
 
+    /// Returns the EWS protocol string for this permission level.
+    /// Uses `strum::Display` for the standard representation.
     pub fn as_str(&self) -> &'static str {
+        // strum generates the Display impl; this method provides a &str reference
         match self {
             Self::None => "None",
             Self::FreeBusy => "FreeBusyTimeOnly",
@@ -284,12 +297,6 @@ impl PermissionLevel {
             Self::PublishingEditor => "PublishingEditor",
             Self::Owner => "Owner",
         }
-    }
-}
-
-impl fmt::Display for PermissionLevel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
     }
 }
 
@@ -315,18 +322,7 @@ impl FromStr for PermissionLevel {
 
 impl From<u8> for PermissionLevel {
     fn from(value: u8) -> Self {
-        match value {
-            1 => Self::FreeBusy,
-            2 => Self::Reviewer,
-            3 => Self::Contributor,
-            4 => Self::NonEditingAuthor,
-            5 => Self::Author,
-            6 => Self::PublishingAuthor,
-            7 => Self::Editor,
-            8 => Self::PublishingEditor,
-            9 => Self::Owner,
-            _ => Self::None,
-        }
+        Self::from_repr(value as usize).unwrap_or(Self::None)
     }
 }
 
@@ -481,7 +477,7 @@ impl DelegateInfo {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, strum::Display)]
 pub enum DelegatePermission {
     #[default]
     None = 0,
@@ -504,12 +500,6 @@ impl DelegatePermission {
             Self::Author => "Author",
             Self::Editor => "Editor",
         }
-    }
-}
-
-impl fmt::Display for DelegatePermission {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
     }
 }
 

--- a/src/permission/types.rs
+++ b/src/permission/types.rs
@@ -210,6 +210,7 @@ impl From<PermissionRights> for u32 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, strum::Display, strum::FromRepr)]
+#[repr(usize)]
 pub enum PermissionLevel {
     #[default]
     #[strum(serialize = "None")]


### PR DESCRIPTION
…so8601-duration crates

- Replace render_ics in calendar.rs with icalendar Calendar/Event/EventLike builder API
- Replace generate_ical in meeting/message.rs with icalendar crate builders
- Replace custom ICS generation in meeting/scheduling.rs with icalendar crate
- Replace custom unfold with icalendar::parser::unfold in ical_parser.rs
- Replace custom ISO 8601 duration parser with iso8601-duration crate
- Add strum::Display derives to PermissionLevel, DelegatePermission, AttendeeRole, AttendeeStatus
- Add strum::FromRepr derive to PermissionLevel
- Remove dead code: fold_ics_line, render_valarm, render_attendee_line, sensitivity_to_class, format_ical_datetime_with_timezone
- Remove manual Display/FromStr impls replaced by strum derives
- 0 errors, 0 warnings, all 69 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new developer guide with build/test instructions, architecture overview, and usage notes for core crates and shared patterns.

* **Refactor**
  * Reworked calendar and message generation to use typed calendar APIs for more robust ICS output.
  * Replaced manual iCalendar folding/assembly with library-driven construction.
  * Switched duration parsing to an ISO8601 parser for improved accuracy.
  * Replaced handwritten enum display logic with derive-based formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->