### PR TITLE
Simplify shutdown_signal function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,9 +170,6 @@ async fn main() -> anyhow::Result<()> {
 
 async fn shutdown_signal() {
     let ctrl_c = async {
-        signal::ctrl_c()
-            .await
-    let ctrl_c = async {
         match signal::ctrl_c().await {
             Ok(()) => {}
             Err(e) => {
@@ -180,7 +177,6 @@ async fn shutdown_signal() {
                 std::future::pending::<()>().await;
             }
         }
-    };
     };
 
  #[cfg(unix)]


### PR DESCRIPTION
Refactor shutdown_signal function to remove redundant async block.